### PR TITLE
Point install one-liner and source URLs at microsoft/skill-recorder

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,19 +18,19 @@ published for the release.
 ### Windows 11 x64 or ARM64
 
 ```powershell
-$commit="<40-character-release-commit>"; $env:SKILL_RECORDER_COMMIT=$commit; irm "https://raw.githubusercontent.com/adilei/skill-recorder/$commit/install.ps1" | iex
+$commit="<40-character-release-commit>"; $env:SKILL_RECORDER_COMMIT=$commit; irm "https://raw.githubusercontent.com/microsoft/skill-recorder/$commit/install.ps1" | iex
 ```
 
 ### macOS or Ubuntu
 
 ```sh
-commit="<40-character-release-commit>"; curl -fsSL "https://raw.githubusercontent.com/adilei/skill-recorder/$commit/install.sh" | SKILL_RECORDER_COMMIT="$commit" bash
+commit="<40-character-release-commit>"; curl -fsSL "https://raw.githubusercontent.com/microsoft/skill-recorder/$commit/install.sh" | SKILL_RECORDER_COMMIT="$commit" bash
 ```
 
 To launch in the background and retain rolling logs on macOS or Ubuntu:
 
 ```sh
-commit="<40-character-release-commit>"; curl -fsSL "https://raw.githubusercontent.com/adilei/skill-recorder/$commit/install.sh" | SKILL_RECORDER_COMMIT="$commit" SKILL_RECORDER_DETACHED=1 bash
+commit="<40-character-release-commit>"; curl -fsSL "https://raw.githubusercontent.com/microsoft/skill-recorder/$commit/install.sh" | SKILL_RECORDER_COMMIT="$commit" SKILL_RECORDER_DETACHED=1 bash
 ```
 
 The commit appears twice deliberately: it pins both the script being executed
@@ -79,7 +79,7 @@ corresponding GitHub Release before executing it.
 ```powershell
 $commit = "<40-character-release-commit>"
 $script = Join-Path $env:TEMP "skill-recorder-install-$commit.ps1"
-Invoke-WebRequest "https://raw.githubusercontent.com/adilei/skill-recorder/$commit/install.ps1" -OutFile $script -UseBasicParsing
+Invoke-WebRequest "https://raw.githubusercontent.com/microsoft/skill-recorder/$commit/install.ps1" -OutFile $script -UseBasicParsing
 Get-FileHash $script -Algorithm SHA256
 Get-Content $script
 $env:SKILL_RECORDER_COMMIT = $commit
@@ -91,7 +91,7 @@ $env:SKILL_RECORDER_COMMIT = $commit
 ```sh
 commit="<40-character-release-commit>"
 script="$(mktemp -t skill-recorder-install.XXXXXX)"
-curl -fsSL "https://raw.githubusercontent.com/adilei/skill-recorder/$commit/install.sh" -o "$script"
+curl -fsSL "https://raw.githubusercontent.com/microsoft/skill-recorder/$commit/install.sh" -o "$script"
 shasum -a 256 "$script"
 cat "$script"
 SKILL_RECORDER_COMMIT="$commit" bash "$script"
@@ -103,7 +103,7 @@ rm -f "$script"
 ```sh
 commit="<40-character-release-commit>"
 script="$(mktemp --suffix=.sh)"
-curl -fsSL "https://raw.githubusercontent.com/adilei/skill-recorder/$commit/install.sh" -o "$script"
+curl -fsSL "https://raw.githubusercontent.com/microsoft/skill-recorder/$commit/install.sh" -o "$script"
 sha256sum "$script"
 cat "$script"
 SKILL_RECORDER_COMMIT="$commit" bash "$script"
@@ -170,7 +170,7 @@ archive rather than repository history.
 $commit = "<40-character-release-commit>"
 $archive = Join-Path $env:TEMP "skill-recorder-$commit.zip"
 $parent = Join-Path $PWD "skill-recorder-source"
-Invoke-WebRequest "https://codeload.github.com/adilei/skill-recorder/zip/$commit" -OutFile $archive -UseBasicParsing
+Invoke-WebRequest "https://codeload.github.com/microsoft/skill-recorder/zip/$commit" -OutFile $archive -UseBasicParsing
 Expand-Archive $archive $parent
 Set-Location (Join-Path $parent "skill-recorder-$commit")
 npm ci
@@ -186,7 +186,7 @@ npm start
 commit="<40-character-release-commit>"
 archive="skill-recorder-$commit.tar.gz"
 source_dir="skill-recorder-$commit"
-curl -fsSL "https://codeload.github.com/adilei/skill-recorder/tar.gz/$commit" -o "$archive"
+curl -fsSL "https://codeload.github.com/microsoft/skill-recorder/tar.gz/$commit" -o "$archive"
 mkdir "$source_dir"
 tar -xzf "$archive" --strip-components=1 -C "$source_dir"
 cd "$source_dir"
@@ -213,7 +213,7 @@ Then use the same pinned source process:
 commit="<40-character-release-commit>"
 archive="skill-recorder-$commit.tar.gz"
 source_dir="skill-recorder-$commit"
-curl -fsSL "https://codeload.github.com/adilei/skill-recorder/tar.gz/$commit" -o "$archive"
+curl -fsSL "https://codeload.github.com/microsoft/skill-recorder/tar.gz/$commit" -o "$archive"
 mkdir "$source_dir"
 tar -xzf "$archive" --strip-components=1 -C "$source_dir"
 cd "$source_dir"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ form can teach the agent to submit *all* of them.
 **macOS / Ubuntu**
 
 ```sh
-commit="<40-character-release-commit>"; curl -fsSL "https://raw.githubusercontent.com/adilei/skill-recorder/$commit/install.sh" | SKILL_RECORDER_COMMIT="$commit" bash
+commit="<40-character-release-commit>"; curl -fsSL "https://raw.githubusercontent.com/microsoft/skill-recorder/$commit/install.sh" | SKILL_RECORDER_COMMIT="$commit" bash
 ```
 
 The release commit pins both the downloaded script and the source it builds. To keep the
@@ -46,7 +46,7 @@ application running after the terminal closes, add `SKILL_RECORDER_DETACHED=1` a
 pipe:
 
 ```sh
-commit="<40-character-release-commit>"; curl -fsSL "https://raw.githubusercontent.com/adilei/skill-recorder/$commit/install.sh" | SKILL_RECORDER_COMMIT="$commit" SKILL_RECORDER_DETACHED=1 bash
+commit="<40-character-release-commit>"; curl -fsSL "https://raw.githubusercontent.com/microsoft/skill-recorder/$commit/install.sh" | SKILL_RECORDER_COMMIT="$commit" SKILL_RECORDER_DETACHED=1 bash
 ```
 
 On macOS the installer also adds a **Skill Recorder (Source)** app to `~/Applications`, so

--- a/install.ps1
+++ b/install.ps1
@@ -481,7 +481,7 @@ if (Test-Path -LiteralPath $sourceDirectory -PathType Container) {
     Write-Step "Obtaining the exact source commit from GitHub."
     $sourceArchive = Join-Path $cacheRoot "skill-recorder-$Commit.zip"
     $sourceArchiveHash = Get-CachedDownload `
-      -Uri "https://codeload.github.com/adilei/skill-recorder/zip/$Commit" `
+      -Uri "https://codeload.github.com/microsoft/skill-recorder/zip/$Commit" `
       -CachePath $sourceArchive
     Assert-ZipArchive -Path $sourceArchive
 
@@ -600,7 +600,7 @@ if (Test-Path -LiteralPath $sourceDirectory -PathType Container) {
       schemaVersion = 1
       distributionMode = "source-local-build"
       commit = $Commit
-      sourceUrl = "https://github.com/adilei/skill-recorder/tree/$Commit"
+      sourceUrl = "https://github.com/microsoft/skill-recorder/tree/$Commit"
       sourceArchiveSha256 = $sourceArchiveHash
       packageLockSha256 = (Get-FileHash -LiteralPath (Join-Path $buildDirectory "package-lock.json") -Algorithm SHA256).Hash.ToLowerInvariant()
       electronExecutableSha256 = (Get-FileHash -LiteralPath $buildElectron -Algorithm SHA256).Hash.ToLowerInvariant()

--- a/install.sh
+++ b/install.sh
@@ -247,7 +247,7 @@ build_source_install() {
   local source_directory="$1"
   local archive="$WORK_DIR/skill-recorder-$COMMIT.tar.gz"
   info "Downloading Skill Recorder source commit $COMMIT."
-  download "https://codeload.github.com/adilei/skill-recorder/tar.gz/$COMMIT" "$archive"
+  download "https://codeload.github.com/microsoft/skill-recorder/tar.gz/$COMMIT" "$archive"
 
   local top_directory
   top_directory="$(tar -tzf "$archive" | awk -F/ 'NR == 1 { first = $1 } END { print first }')"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "description": "Records a user's on-screen work session and derives a structured description for building AI-agent skills.",
   "author": "Skill Recorder contributors",
-  "repository": "github:adilei/skill-recorder",
+  "repository": "github:microsoft/skill-recorder",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/scripts/compliance.mjs
+++ b/scripts/compliance.mjs
@@ -1267,7 +1267,7 @@ async function downloadWithRetry(url, target, fetchImpl) {
           accept: "application/octet-stream, text/plain;q=0.9, */*;q=0.8",
           "user-agent":
             "Mozilla/5.0 (compatible; SkillRecorderCompliance/1.0; " +
-            "+https://github.com/adilei/skill-recorder)",
+            "+https://github.com/microsoft/skill-recorder)",
         },
       });
       if (!response.ok || !response.body) {
@@ -1320,7 +1320,7 @@ export function renderRelinking(native, sourceManifest, policy, platform = proce
     "# Replacing and relinking native libraries",
     "",
     "Skill Recorder's own source is available under the MIT License at",
-    "https://github.com/adilei/skill-recorder. The native libraries listed in",
+    "https://github.com/microsoft/skill-recorder. The native libraries listed in",
     "`NATIVE-COMPONENTS.json` remain under their own licenses.",
     "",
     "The packaged application keeps Sharp, libvips, and related native modules outside",

--- a/scripts/compliance.test.mjs
+++ b/scripts/compliance.test.mjs
@@ -323,7 +323,7 @@ test("source and release instructions remain compliance-preserving", async () =>
   assert.match(windowsInstaller, /\^\[0-9a-fA-F\]\{40\}\$/);
   assert.match(
     windowsInstaller,
-    /https:\/\/codeload\.github\.com\/adilei\/skill-recorder\/zip\/\$Commit/,
+    /https:\/\/codeload\.github\.com\/microsoft\/skill-recorder\/zip\/\$Commit/,
   );
   assert.match(windowsInstaller, /https:\/\/nodejs\.org\/dist\/index\.json/);
   assert.match(windowsInstaller, /NPM_CONFIG_REGISTRY = "https:\/\/registry\.npmjs\.org\/"/);
@@ -364,7 +364,7 @@ test("source and release instructions remain compliance-preserving", async () =>
   assert.match(windowsInstaller, /@?\("run", "build"\)/);
   assert.doesNotMatch(
     windowsInstaller,
-    /github\.com\/adilei\/skill-recorder\/releases\/download/i,
+    /github\.com\/microsoft\/skill-recorder\/releases\/download/i,
   );
   assert.doesNotMatch(windowsInstaller, /\/(?:master|main)\/install\.ps1/i);
 
@@ -382,7 +382,7 @@ test("source and release instructions remain compliance-preserving", async () =>
   assert.match(unixInstaller, /\^\[0-9a-fA-F\]\{40\}\$/);
   assert.match(
     unixInstaller,
-    /https:\/\/codeload\.github\.com\/adilei\/skill-recorder\/tar\.gz\/\$COMMIT/,
+    /https:\/\/codeload\.github\.com\/microsoft\/skill-recorder\/tar\.gz\/\$COMMIT/,
   );
   assert.match(unixInstaller, /https:\/\/nodejs\.org\/dist\/latest-v24\.x/);
   assert.match(unixInstaller, /NPM_CONFIG_REGISTRY="https:\/\/registry\.npmjs\.org\/"/);
@@ -399,7 +399,7 @@ test("source and release instructions remain compliance-preserving", async () =>
   assert.match(unixInstaller, /@github\/copilot-\$\{PLATFORM\}-\$\{ARCHITECTURE\}/);
   assert.doesNotMatch(
     unixInstaller,
-    /github\.com\/adilei\/skill-recorder\/releases\/download/i,
+    /github\.com\/microsoft\/skill-recorder\/releases\/download/i,
   );
   assert.doesNotMatch(unixInstaller, /\/(?:master|main)\/install\.sh/i);
 


### PR DESCRIPTION
## What

After the move from `adilei/skill-recorder` to `microsoft/skill-recorder`, the install one-liner and other repo URLs were still pointing at the old owner. This repoints them.

Changed `adilei/skill-recorder` → `microsoft/skill-recorder` in:

- **`README.md`** / **`INSTALL.md`** — the copy-paste install one-liners and the download/inspect URLs
- **`install.sh`** / **`install.ps1`** — the `codeload.github.com` source-archive download URLs and the `sourceUrl` recorded in install metadata
- **`package.json`** — the `repository` field
- **`scripts/compliance.mjs`** — the compliance fetch `user-agent` and the MIT-source URL in the generated native-components notice
- **`scripts/compliance.test.mjs`** — the matching URL assertions

## Verification

The pinned release commits still resolve on the new repo (`raw.githubusercontent.com/microsoft/skill-recorder/<commit>/install.sh` → HTTP 200), so the one-liner works unchanged aside from the owner.

`node --test scripts/compliance.test.mjs` → **13/13 passing**, including *"source and release instructions remain compliance-preserving"*.

## Note — already-published releases

The published GitHub Release descriptions (v0.1.0–v0.3.0) contain the same old-owner one-liner. Those live on the Releases page, not in the repo, and editing them needs push access to `microsoft/skill-recorder` (the CLI token here is read-only). A maintainer can update them with `gh release edit <tag> --notes-file <fixed-body>`.