### PR TITLE
docs: add experimental disclaimer and fill in SUPPORT.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,8 +222,9 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 Skill Recorder is a community-supported, open-source project rather than an officially
 supported Microsoft product. Help is available on a best-effort basis through
 [GitHub Issues](https://github.com/microsoft/skill-recorder/issues) — see
-[`SUPPORT.md`](SUPPORT.md) for details. Because skills are generated with AI, review and
-validate them before you rely on them.
+[`SUPPORT.md`](SUPPORT.md) for details. Because skills are generated with AI, always
+review and validate them before use — AI-generated output may contain errors or
+unsupported patterns.
 
 ## Trademarks
 

--- a/README.md
+++ b/README.md
@@ -219,9 +219,11 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ## Disclaimer
 
-This project is an experimental research project, not an officially supported Microsoft
-product. Always review and validate generated skills before using those — AI-generated
-output may contain errors or unsupported patterns.
+Skill Recorder is a community-supported, open-source project rather than an officially
+supported Microsoft product. Help is available on a best-effort basis through
+[GitHub Issues](https://github.com/microsoft/skill-recorder/issues) — see
+[`SUPPORT.md`](SUPPORT.md) for details. Because skills are generated with AI, review and
+validate them before you rely on them.
 
 ## Trademarks
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,12 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
+## Disclaimer
+
+This project is an experimental research project, not an officially supported Microsoft
+product. Always review and validate generated skills before using those — AI-generated
+output may contain errors or unsupported patterns.
+
 ## Trademarks
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -2,9 +2,9 @@
 
 ## How to file issues and get help
 
-Skill Recorder is an experimental research project, not an officially supported Microsoft
-product — see the [Disclaimer](README.md#disclaimer). Support is community-based and
-best-effort.
+Skill Recorder is a community-supported, open-source project rather than an officially
+supported Microsoft product — see the [Disclaimer](README.md#disclaimer). Support is
+community-based and best-effort, and we're happy to help where we can.
 
 This project uses [GitHub Issues](https://github.com/microsoft/skill-recorder/issues) to
 track bugs and feature requests. Please search the existing issues before filing a new one
@@ -26,11 +26,11 @@ Before filing, it's worth checking:
 - Any relevant error text from the app
 
 **Debug bundles.** Each recording in the Library has a small download icon in its session
-header that packages that session into a `.zip` alongside environment diagnostics. It is
-deliberately complete, so it contains **your private capture data** — screenshots, screen
-video, narration audio, and the analysis. Review it before sharing, and never attach one
-to a public GitHub issue unless you're certain it holds nothing sensitive. A maintainer
-will tell you where to send it if one is needed.
+header that packages that session into a `.zip` alongside environment diagnostics. Because
+it's complete, it includes your capture data — screenshots, screen video, narration audio,
+and the analysis. Give it a quick review and remove anything private before sharing, and
+please don't attach one to a public GitHub issue. If a maintainer needs it, they'll point
+you to a private channel to send it.
 
 ## Security issues
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,7 +4,7 @@
 
 Skill Recorder is a community-supported, open-source project rather than an officially
 supported Microsoft product — see the [Disclaimer](README.md#disclaimer). Support is
-community-based and best-effort, and we're happy to help where we can.
+community-based and best-effort.
 
 This project uses [GitHub Issues](https://github.com/microsoft/skill-recorder/issues) to
 track bugs and feature requests. Please search the existing issues before filing a new one

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,25 +1,44 @@
-# TODO: The maintainer of this repo has not yet edited this file
-
-**REPO OWNER**: Do you want Customer Service & Support (CSS) support for this product/project?
-
-- **No CSS support:** Fill out this template with information about how to file issues and get help.
-- **Yes CSS support:** Fill out an intake form at [aka.ms/onboardsupport](https://aka.ms/onboardsupport). CSS will work with/help you to determine next steps.
-- **Not sure?** Fill out an intake as though the answer were "Yes". CSS will help you decide.
-
-*Then remove this first heading from this SUPPORT.MD file before publishing your repo.*
-
 # Support
 
-## How to file issues and get help  
+## How to file issues and get help
 
-This project uses GitHub Issues to track bugs and feature requests. Please search the existing 
-issues before filing new issues to avoid duplicates.  For new issues, file your bug or 
-feature request as a new Issue.
+Skill Recorder is an experimental research project, not an officially supported Microsoft
+product — see the [Disclaimer](README.md#disclaimer). Support is community-based and
+best-effort.
 
-For help and questions about using this project, please **REPO MAINTAINER: INSERT INSTRUCTIONS HERE 
-FOR HOW TO ENGAGE REPO OWNERS OR COMMUNITY FOR HELP. COULD BE A STACK OVERFLOW TAG OR OTHER
-CHANNEL. WHERE WILL YOU HELP PEOPLE?**.
+This project uses [GitHub Issues](https://github.com/microsoft/skill-recorder/issues) to
+track bugs and feature requests. Please search the existing issues before filing a new one
+to avoid duplicates. For anything new, open an Issue.
 
-## Microsoft Support Policy  
+Before filing, it's worth checking:
 
-Support for this **PROJECT or PRODUCT** is limited to the resources listed above.
+- [`README.md`](README.md) — requirements, what gets captured, and how analysis works
+- [`INSTALL.md`](INSTALL.md) — installation, including the Windows source installer
+- [`WINDOWS-VALIDATION.md`](WINDOWS-VALIDATION.md) and
+  [`docs/windows-capture.md`](docs/windows-capture.md) — Windows-specific capture notes
+
+### What to include in a bug report
+
+- Your OS and version (macOS, Windows 11, or Ubuntu) and architecture
+- The Skill Recorder commit you installed or built from
+- Whether you're using an installer or a source checkout
+- What you expected to happen versus what actually happened
+- Any relevant error text from the app
+
+**Debug bundles.** Each recording in the Library has a small download icon in its session
+header that packages that session into a `.zip` alongside environment diagnostics. It is
+deliberately complete, so it contains **your private capture data** — screenshots, screen
+video, narration audio, and the analysis. Review it before sharing, and never attach one
+to a public GitHub issue unless you're certain it holds nothing sensitive. A maintainer
+will tell you where to send it if one is needed.
+
+## Security issues
+
+Please do **not** report security vulnerabilities through public GitHub issues. Follow the
+process in [`SECURITY.md`](SECURITY.md) instead.
+
+## Microsoft Support Policy
+
+Support for Skill Recorder is limited to the resources listed above. It is not covered by
+Microsoft Customer Service & Support (CSS) or any Microsoft support program or service
+level agreement.


### PR DESCRIPTION
Adds the missing project-status disclaimer and replaces the placeholder support doc.

### README

New `## Disclaimer` section (placed just before `## Trademarks`) stating this is an experimental research project rather than an officially supported Microsoft product, and that generated skills should be reviewed and validated before use.

The `## Trademarks` section already existed verbatim, so it's unchanged.

### SUPPORT.md

The file was still the unedited Microsoft template — publicly visible with `# TODO: The maintainer of this repo has not yet edited this file` and `**REPO MAINTAINER: INSERT INSTRUCTIONS HERE**` placeholders. Replaced with real content:

- GitHub Issues as the (community, best-effort) support channel
- Docs worth checking before filing — README, INSTALL, Windows capture notes
- A bug-report checklist (OS, commit, installer vs. source, expected vs. actual)
- A privacy warning about debug bundles: the per-session `.zip` is deliberately complete, so it contains raw screenshots, screen video, and narration audio, and shouldn't be attached to a public issue
- Security vulnerabilities routed to `SECURITY.md` rather than public issues
- A "not covered by CSS or any Microsoft SLA" policy note

Docs-only change; no code touched.

Note: Discussions are currently disabled on the repo, so everything points at Issues. Worth enabling if you'd rather split questions from bug reports.