### PR TITLE
Describer: name a narrated goal as the intent, not "researched how to build it"

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,31 @@
+# Repository instructions for coding agents
+
+## Pull requests target the active **release branch**, not `main`
+
+Ongoing work in this repository lands on the **current release branch**, not `main`.
+Release branches are named `release/<semver>` — currently **`release/0.3.0`**, the
+highest-versioned `release/*` branch on `origin`. `main` trails the release branch and
+only advances when a version is cut and merged (see [`RELEASING.md`](../RELEASING.md)).
+
+Unless a task explicitly says otherwise:
+
+- **Base new work on the current release branch**, not `main`:
+
+  ```sh
+  git fetch origin
+  git switch -c <your-branch> origin/release/0.3.0
+  ```
+
+- **Open pull requests with the current release branch as the base**, not `main`:
+
+  ```sh
+  gh pr create --repo microsoft/skill-recorder --base release/0.3.0 --head <your-branch>
+  ```
+
+- **Find the current release branch** (pick the highest semver) with:
+
+  ```sh
+  git ls-remote --heads origin 'release/*'
+  ```
+
+Target `main` only for the release merge described in [`RELEASING.md`](../RELEASING.md).

--- a/electron/describer/instructions.ts
+++ b/electron/describer/instructions.ts
@@ -55,7 +55,10 @@ All times are **\`atMs\` = milliseconds since the recording started**.
 ## Method
 1. **Read the timeline** (get_timeline) to get the shape of the session.
 2. **Read any narration** (get_narration). If the user narrated, their words state
-   the intent directly — anchor your hypothesis and step names to them.
+   the intent directly — anchor your hypothesis and step names to them. Notice whether
+   they are narrating the task they are performing or stating a goal/automation they want
+   built — the latter changes how you frame the intent (see "When the narration states a
+   goal to build, not a task performed").
 3. **Form a hypothesis** about the overall intent from apps + urls + commands.
 4. **Read events** (get_events) around anything unclear — clipboard text, exact
    URLs, the sequence of title changes.
@@ -108,6 +111,30 @@ Guardrails — do not over-prune:
   note the omission in an adjacent step's \`detail\` or in \`intentRationale\`, but the intent
   sentence and every step title must stay about the actual task.
 
+## When the narration states a goal to build, not a task performed
+Most sessions are a task the user *performs*, and that task is the intent. But sometimes the
+narration states what the user **wants** — a desired outcome or an automation to build ("I want
+an automation that…", "the goal is…", "it should notify me when…") — while the on-screen actions
+are only **research/scoping** toward it: looking up who or what it involves, opening the target
+app, confirming where the data lives. Handle these sessions specially.
+
+- **Make the intent the goal itself.** Name the outcome the user is after, committed to and in
+  plain language — e.g. "Notify the team's Teams chat whenever a non-maintainer opens a GitHub
+  issue." Do NOT wrap it in meta framing about the scoping: never "Researched what's needed to
+  build…", "Explored how to…", or "Figured out how to set up…". The act of scoping is not the
+  intent; the thing being scoped is.
+- **Keep the steps faithful to what was actually done.** The research/scoping actions remain the
+  ordered steps, in the past tense — they are the evidence for the pieces the goal needs (where
+  the issues live, who the maintainers are, which chat to post to). Do not invent steps that
+  perform the goal; the user only scoped it.
+- **Ground it in the narration.** Cite the stated goal in intentRationale, and set
+  intentConfidence from how explicitly it was stated — an outright "I want an automation that…"
+  is a high-confidence intent even though the task itself was never demonstrated.
+
+This applies ONLY when the narration expresses a goal or outcome to build. When the user is just
+narrating the task they are doing ("I'm gathering quotes on habits"), that task is the intent as
+usual — do not turn ordinary research into a hypothetical automation.
+
 ## Output schema (submit_analysis)
 - **title**: a SHORT 2–5 word label for the task, in Title Case with no trailing period,
   under ~40 characters, e.g. "Research Habit Articles", "Extract Invoice Data", "Compare
@@ -116,7 +143,10 @@ Guardrails — do not over-prune:
   truncated**. (e.g. intent "Copy the last few messages of a Teams chat into a new Apple
   Note" → title "Save Teams Chat To Notes".)
 - **intent**: one sentence naming the user's goal, e.g. "Research and compare
-  articles on building better habits" or "Submit an expense report".
+  articles on building better habits" or "Submit an expense report". When the user narrated
+  a goal or automation they want built rather than performing the task, name that goal
+  directly (see the section above) — never wrap it as "Researched what's needed to build…"
+  or "Explored how to…".
 - **intentConfidence**: "high" | "medium" | "low".
 - **intentRationale**: 1–2 sentences citing the evidence for the intent, in the same past-tense
   voice addressed to the user — e.g. "Navigated from the technical guide to the blog post, copied


### PR DESCRIPTION
## Problem

When a recording's **voice narration states a goal/automation the user wants built** — rather than narrating a task they actually perform — and the on-screen actions are only *research/scoping* toward it, the describer produced a **meta intent**:

> "Researched what's needed to build an automation that flags GitHub issues opened by non-maintainers and posts a notification to the team's Microsoft Teams group chat."

That "Researched what's needed to build…" wrapper is the weird part: it isn't a repeatable task, it fights the narration (which stated a concrete goal), and it feeds a broken intent into the Skill/Automation builders, which explicitly *"generalize from the intent."* The actually-buildable goal ("notify Teams when a non-maintainer opens an issue") ends up buried inside the wrapper.

Nothing in the describer handled the "narrated a goal to build" case before.

## Fix

`electron/describer/instructions.ts`:

- New section **"When the narration states a goal to build, not a task performed"**: make the **intent the goal itself** (no `Researched what's needed to build…` / `Explored how to…` framing), keep the research actions as the ordered **steps** (they're the evidence for the goal's pieces), and ground it in the narration via `intentRationale` / `intentConfidence`.
- Reinforcing pointers at the two decision points: the narration-reading step in **Method**, and the **`intent`** output-field bullet.
- Scoped so it only triggers on aspirational narration — ordinary "I'm researching X" tasks are unchanged.

## Repo workflow

Adds `.github/copilot-instructions.md` so agents working in this repo **base work on, and open PRs against, the current release branch** (`release/0.3.0`) instead of `main` — with a command to discover the highest-versioned `release/*` branch as it rolls forward. This PR targets `release/0.3.0` accordingly.

## Validation

Prompt-only change (a template-string constant) plus a new markdown file — no type surface changes. Verified the describer module still loads and both edits are present via Node 24 type-stripping. Full `npm ci` was skipped locally (heavy Electron/native deps); CI runs typecheck/tests on the PR.

## Suggested follow-up

Add an eval scenario under `evals/scenarios/` for the "narrated a goal to build, only scoped it" case to lock this behavior in against regression.
