### PR TITLE
Fix Windows source installer long-path cleanup

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,20 +29,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Validate source installer guardrails
-        shell: pwsh
+        shell: powershell
         run: |
-          $tokens = $null
-          $parseErrors = $null
           $path = (Resolve-Path "install.ps1").Path
-          [void][System.Management.Automation.Language.Parser]::ParseFile(
-            $path,
-            [ref]$tokens,
-            [ref]$parseErrors
-          )
-          if ($parseErrors.Count -ne 0) {
-            $parseErrors | ForEach-Object { Write-Error $_.Message }
-            throw "install.ps1 contains PowerShell syntax errors"
-          }
+          & .\scripts\install-windows.test.ps1 -InstallerPath $path
           $beforeErrorPreference = $ErrorActionPreference
           $beforeProgressPreference = $ProgressPreference
           $env:SKILL_RECORDER_COMMIT = "master"

--- a/install.ps1
+++ b/install.ps1
@@ -121,6 +121,65 @@ function Remove-CachedDownload {
   }
 }
 
+function ConvertTo-ExtendedLengthPath {
+  param([Parameter(Mandatory)][string]$Path)
+
+  $fullPath = [IO.Path]::GetFullPath($Path)
+  if ($fullPath.StartsWith("\\?\")) {
+    return $fullPath
+  }
+  if ($fullPath.StartsWith("\\")) {
+    return "\\?\UNC\" + $fullPath.Substring(2)
+  }
+  return "\\?\" + $fullPath
+}
+
+function Move-DirectoryTree {
+  param(
+    [Parameter(Mandatory)][string]$Source,
+    [Parameter(Mandatory)][string]$Destination
+  )
+
+  $extendedSource = ConvertTo-ExtendedLengthPath -Path $Source
+  $extendedDestination = ConvertTo-ExtendedLengthPath -Path $Destination
+  if (-not [IO.Directory]::Exists($extendedSource)) {
+    throw "Directory to move does not exist: $Source"
+  }
+  if (
+    [IO.Directory]::Exists($extendedDestination) -or
+    [IO.File]::Exists($extendedDestination)
+  ) {
+    throw "Refusing to overwrite an existing path: $Destination"
+  }
+
+  [IO.Directory]::Move($extendedSource, $extendedDestination)
+}
+
+function Remove-DirectoryTree {
+  param([Parameter(Mandatory)][string]$Path)
+
+  $extendedPath = ConvertTo-ExtendedLengthPath -Path $Path
+  if (-not [IO.Directory]::Exists($extendedPath)) {
+    return
+  }
+
+  $attributes = [IO.File]::GetAttributes($extendedPath)
+  if (($attributes -band [IO.FileAttributes]::ReparsePoint) -eq 0) {
+    foreach ($entry in [IO.Directory]::EnumerateFileSystemEntries($extendedPath)) {
+      $entryAttributes = [IO.File]::GetAttributes($entry)
+      if (($entryAttributes -band [IO.FileAttributes]::Directory) -ne 0) {
+        Remove-DirectoryTree -Path $entry
+      } else {
+        [IO.File]::SetAttributes($entry, [IO.FileAttributes]::Normal)
+        [IO.File]::Delete($entry)
+      }
+    }
+  }
+
+  [IO.File]::SetAttributes($extendedPath, [IO.FileAttributes]::Normal)
+  [IO.Directory]::Delete($extendedPath, $false)
+}
+
 function Assert-ZipArchive {
   param([Parameter(Mandatory)][string]$Path)
 
@@ -498,7 +557,10 @@ if (Test-Path -LiteralPath $sourceDirectory -PathType Container) {
     if ($sourceCandidates[0].Name -ne $expectedSourceDirectoryName) {
       throw "GitHub source directory does not match commit $Commit."
     }
-    $buildDirectory = $sourceCandidates[0].FullName
+    $buildDirectory = Join-Path $stagingDirectory "build"
+    Move-DirectoryTree `
+      -Source $sourceCandidates[0].FullName `
+      -Destination $buildDirectory
 
     Assert-RequiredPaths -Root $buildDirectory -RelativePaths @(
       "LICENSE",
@@ -614,11 +676,13 @@ if (Test-Path -LiteralPath $sourceDirectory -PathType Container) {
     if (Test-Path -LiteralPath $sourceDirectory) {
       throw "Refusing to overwrite an existing source installation: $sourceDirectory"
     }
-    Move-Item -LiteralPath $buildDirectory -Destination $sourceDirectory
+    Move-DirectoryTree -Source $buildDirectory -Destination $sourceDirectory
     Remove-CachedDownload -CachePath $sourceArchive
   } finally {
-    if (Test-Path -LiteralPath $stagingDirectory) {
-      Remove-Item -LiteralPath $stagingDirectory -Recurse -Force
+    try {
+      Remove-DirectoryTree -Path $stagingDirectory
+    } catch {
+      Write-Warning "Could not remove temporary installation files at ${stagingDirectory}: $($_.Exception.Message)"
     }
   }
 }

--- a/scripts/install-windows.test.ps1
+++ b/scripts/install-windows.test.ps1
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Skill Recorder contributors
+
+param(
+  [string]$InstallerPath = (Join-Path (Split-Path -Parent $PSScriptRoot) "install.ps1")
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$tokens = $null
+$parseErrors = $null
+$installerAst = [System.Management.Automation.Language.Parser]::ParseFile(
+  $InstallerPath,
+  [ref]$tokens,
+  [ref]$parseErrors
+)
+if ($parseErrors.Count -ne 0) {
+  $parseErrors | ForEach-Object { Write-Error $_.Message }
+  throw "install.ps1 contains PowerShell syntax errors"
+}
+
+$helperNames = @(
+  "ConvertTo-ExtendedLengthPath",
+  "Move-DirectoryTree",
+  "Remove-DirectoryTree"
+)
+$functionDefinitions = @(
+  $installerAst.FindAll(
+    {
+      param($node)
+      $node -is [System.Management.Automation.Language.FunctionDefinitionAst]
+    },
+    $true
+  )
+)
+$helperSource = @(
+  foreach ($helperName in $helperNames) {
+    $matches = @($functionDefinitions | Where-Object Name -eq $helperName)
+    if ($matches.Count -ne 1) {
+      throw "Expected one $helperName definition in install.ps1, found $($matches.Count)."
+    }
+    $matches[0].Extent.Text
+  }
+)
+. ([scriptblock]::Create($helperSource -join [Environment]::NewLine))
+
+$uncPath = ConvertTo-ExtendedLengthPath -Path "\\server\share\folder"
+if ($uncPath -ne "\\?\UNC\server\share\folder") {
+  throw "Extended-length UNC conversion returned an unexpected path: $uncPath"
+}
+
+$testRoot = Join-Path (
+  [IO.Path]::GetTempPath()
+) ("skill-recorder-installer-" + [guid]::NewGuid().ToString("N"))
+$sourceDirectory = Join-Path $testRoot ("source-" + ("a" * 96))
+$nestedDirectoryName = "b" * 120
+$sourceFile = Join-Path (
+  Join-Path $sourceDirectory $nestedDirectoryName
+) "coverage.json"
+$destinationDirectory = Join-Path $testRoot "build"
+$destinationFile = Join-Path (
+  Join-Path $destinationDirectory $nestedDirectoryName
+) "coverage.json"
+
+try {
+  [IO.Directory]::CreateDirectory(
+    (ConvertTo-ExtendedLengthPath -Path (Split-Path -Parent $sourceFile))
+  ) | Out-Null
+  [IO.File]::WriteAllText(
+    (ConvertTo-ExtendedLengthPath -Path $sourceFile),
+    "installer long-path regression"
+  )
+  [IO.File]::SetAttributes(
+    (ConvertTo-ExtendedLengthPath -Path $sourceFile),
+    [IO.FileAttributes]::ReadOnly
+  )
+
+  if ($sourceFile.Length -le 260) {
+    throw "Long-path test setup produced only $($sourceFile.Length) characters."
+  }
+
+  Move-DirectoryTree -Source $sourceDirectory -Destination $destinationDirectory
+  if ([IO.Directory]::Exists((ConvertTo-ExtendedLengthPath -Path $sourceDirectory))) {
+    throw "Move-DirectoryTree left the source directory behind."
+  }
+  if (-not [IO.File]::Exists((ConvertTo-ExtendedLengthPath -Path $destinationFile))) {
+    throw "Move-DirectoryTree did not move the long-path test file."
+  }
+
+  Remove-DirectoryTree -Path $destinationDirectory
+  if ([IO.Directory]::Exists((ConvertTo-ExtendedLengthPath -Path $destinationDirectory))) {
+    throw "Remove-DirectoryTree left the destination directory behind."
+  }
+} finally {
+  Remove-DirectoryTree -Path $testRoot
+}
+
+Write-Host "Windows installer long-path tests passed."


### PR DESCRIPTION
## Summary
- shorten the extracted staging path before `npm ci` creates deeply nested dependencies
- use extended-length Windows paths for directory moves and cleanup
- keep cleanup failures from masking the original installation error
- add a PowerShell 5.1 regression test for `MAX_PATH` and read-only files

## Testing
- Windows PowerShell 5.1 installer regression and guardrail checks
- PowerShell 7 installer regression check