### PR TITLE
Release 0.3.1: fix Windows installer long paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skill-recorder",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skill-recorder",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-recorder",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Records a user's on-screen work session and derives a structured description for building AI-agent skills.",
   "author": "Skill Recorder contributors",
   "repository": "github:microsoft/skill-recorder",


### PR DESCRIPTION
## Summary

- Prepare the source-only Skill Recorder v0.3.1 release candidate as a compatible source-installer patch.
- Carry forward the merged #30 MAX_PATH fix: shorten the Windows staging path, use extended-length filesystem operations for deeply nested dependency moves and cleanup, preserve the original installation error when cleanup also fails, and cover the behavior with a PowerShell 5.1 regression test.
- Bump only the package version metadata from 0.3.0 to 0.3.1.

## Dependencies and compliance

There are no dependency changes and no compliance-boundary changes.

## Validation

- `npm run typecheck`
- Confirmed the diff contains only the version fields in `package.json` and `package-lock.json`.