### PR TITLE
On-device sensitive-detail detection + redaction (pre-send)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ release
 
 # Eval run outputs (timestamped result logs)
 evals/results/
+# Opt-in OCR eval's downloaded traineddata cache
+evals/.cache/

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -244,8 +244,8 @@ dependency legal files.
 ## Licensing boundary
 
 The source channels distribute this repository's MIT-licensed source. The
-user's package manager obtains Sharp/libvips, ONNX Runtime, the unmodified
-GitHub Copilot CLI, and other npm dependencies through its configured registry;
+user's package manager obtains Sharp/libvips, ONNX Runtime, Tesseract.js, the
+unmodified GitHub Copilot CLI, and other npm dependencies through its configured registry;
 the installer obtains the reviewed Electron runtime from GitHub. Canonical
 registry URLs and integrity hashes keep the lockfile portable across direct
 npmjs access and compatible corporate mirrors. The local build is not a
@@ -257,8 +257,9 @@ Each platform's compliance check retains:
 - complete license files installed with npm packages, including the Copilot CLI
   license;
 - Electron and Chromium runtime notices;
-- canonical GPL, LGPL, and MPL texts under `.compliance/licenses`;
+- canonical GPL, LGPL, MPL, and Artistic-2.0 texts under `.compliance/licenses`;
 - platform-specific Sharp/libvips and ONNX Runtime notices under `.compliance`;
+- Tesseract WebAssembly component notices under `.compliance/tesseract-core`;
 - an inventory with no unresolved dependency-license entries.
 
 Anyone redistributing a generated application must instead use the supported

--- a/README.md
+++ b/README.md
@@ -122,6 +122,17 @@ does Skill Recorder send the event timeline (window/document titles, URLs, and c
 previews), extracted screen images, narration text, and anything else you provide to
 GitHub's cloud service for Copilot to process.
 
+**Before anything is sent, a pre-send scan runs on your computer.** Skill Recorder
+inspects the text that Analyze would upload — window/document titles, URLs, clipboard
+previews, terminal commands, markers, and transcribed narration — for likely secrets and
+personal details (private keys, API tokens, credentials, JWTs, emails, and payment-card
+and Social Security numbers). Anything it finds is masked before it leaves your machine,
+and Analyze shows you a redacted summary of what was hidden (values are masked; raw
+secrets are never stored or displayed). **Advanced protection** (on by default) extends
+the same scan to your screen images: frames are read on-device and matching regions are
+blurred before any image is uploaded. This is a safety net, not a guarantee — no detector
+catches everything, so keeping secrets out of the recording is still the best protection.
+
 > ⚠️ **Please don't capture secrets.** Passwords, access tokens, API keys, credentials, and
 > other confidential information should never be recorded, typed, pasted, shown, copied,
 > or narrated during a session.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -68,6 +68,8 @@ requirements, and upstream provenance first.
 | Electron or Chromium | Review the Electron archive and checksums, Chromium notices, FFmpeg revision/source/patches, and every supported platform hash. |
 | Sharp or sharp-libvips | Review package licenses, native dependency versions, build repositories, patches, source archives, and relinking instructions. |
 | ONNX Runtime | Review the exact release/development revision, license, notices, native packages, and source reference. |
+| Tesseract.js, Tesseract.js-core, or tessdata | Review the exact npm versions, WASM build commit and submodules, embedded-library notices, language-data commit/hash, and fixed source archives. |
+| Artistic-2.0 package | Retain the package notice and complete Artistic-2.0 text; include valid source instructions or the exact Standard Version source. |
 | New native or copyleft component | Add exact notices, canonical license text, complete corresponding source, build scripts/patches, and relinking instructions where required. |
 | Font, image, model, recording, or other asset | Record its provenance and written redistribution authorization; do not assume application code licenses cover assets. |
 

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -11,7 +11,7 @@ Electron's exact notices are retained under `resources/compliance/electron/`;
 platforms that preserve Electron's root notice files carry those copies too.
 
 The dependency tree is otherwise permissive (MIT, ISC, Apache-2.0, BSD,
-BlueOak-1.0.0) and compatible with distributing this application under MIT.
+Artistic-2.0, BlueOak-1.0.0) and compatible with distributing this application under MIT.
 Those components remain under their own terms; the generated
 `THIRD-PARTY-LICENSES.txt` preserves their license and attribution text.
 
@@ -30,6 +30,18 @@ Those components remain under their own terms; the generated
   code and model weights are released under the **MIT License**. The downloaded
   model remains subject to its publisher's applicable terms and does not change
   Skill Recorder's MIT license.
+
+### Tesseract English language data — `tessdata_fast/eng.traineddata`
+- Advanced protection downloads the English OCR data directly from
+  [`tesseract-ocr/tessdata_fast`](https://github.com/tesseract-ocr/tessdata_fast)
+  only when OCR is enabled; it is not bundled with Skill Recorder.
+- The file is pinned to commit
+  [`65727574dfcd264acbb0c3e07860e4e9e9b22185`](https://github.com/tesseract-ocr/tessdata_fast/tree/65727574dfcd264acbb0c3e07860e4e9e9b22185)
+  and SHA-256
+  `7d4322bd2a7749724879683fc3912cb542f19906c83bcc1a52132556427170b2`.
+- The language data is Apache-2.0. Its exact license is retained under
+  `resources/compliance/tesseract-core/`, even though the model is fetched
+  from its publisher rather than redistributed in the application.
 
 ## Bundled runtime components
 
@@ -87,12 +99,34 @@ packages omit standalone license and third-party-notice files, so exact notices
 from each pinned source revision are included under
 `resources/compliance/onnxruntime/`.
 
-### Copyleft release materials
+### Tesseract OCR WebAssembly — `tesseract.js` and `tesseract.js-core`
+
+- `tesseract.js@7.0.0` and `tesseract.js-core@7.0.0` are Apache-2.0.
+  Apache-2.0 does not require corresponding source, but it does require
+  retaining the license, copyright, and any applicable notices.
+- The packaged WebAssembly is built from
+  [`tesseract.js-core` commit `acffef2b66eb44a31df297e11d905f4b39001068`](https://github.com/naptha/tesseract.js-core/tree/acffef2b66eb44a31df297e11d905f4b39001068).
+  Its build scripts statically link the pinned GIFLIB, Leptonica, IJG libjpeg,
+  libpng, libtiff, libwebp, OpenLibm, Tesseract, and zlib revisions recorded
+  in `SOURCE-MANIFEST.json`.
+- Exact upstream terms are retained under
+  `resources/compliance/tesseract-core/`; fixed source archives for the build
+  scripts and all nine linked projects are retained under
+  `resources/compliance/sources/`.
+- As required by the IJG terms: **This software is based in part on the work
+  of the Independent JPEG Group.**
+- OpenLibm's source tree contains LGPL-covered test files, but its static
+  library build does not compile or link those tests into the OCR WebAssembly.
+
+### Release source materials
 
 Redistributable builds include the complete GPL-3.0, LGPL-2.1, LGPL-3.0, and
 MPL-2.0 texts. They also include source archives for Electron's FFmpeg revision,
 Sharp, libvips, every library embedded in the Sharp native payload, the
 applicable packaging repositories, and all externally applied build patches.
+For reproducibility and notice preservation, the bundle also includes the
+fixed Tesseract.js-core build source, all statically linked OCR sources, and
+verbatim source packages for Artistic-2.0 dependencies.
 `SOURCE-MANIFEST.json` records the origin, version, SHA-256, and purpose of every
 file. Every remote payload is checked against a reviewed SHA-256 before use;
 the FFmpeg archive is deterministically generated from its pinned Git commit.
@@ -106,11 +140,20 @@ and explains how to rebuild and replace them.
 - `sharp` — Apache-2.0; see the Sharp/libvips section for native payload terms
 
 ## Apache-2.0 components
-Some dependencies (e.g. `sharp`) are Apache-2.0, which requires retaining their
+Some dependencies (including `sharp`, `tesseract.js`, and
+`tesseract.js-core`) are Apache-2.0, which requires retaining their
 copyright, license, and any `NOTICE` file contents. The release process collects
 these from the exact installed dependency tree into
 `resources/compliance/THIRD-PARTY-LICENSES.txt` and fails if any package lacks
 reviewed license material.
+
+## Artistic-2.0 components
+
+Secretlint's text-source handling introduces `binaryextensions`, `editions`,
+`istextorbinary`, `textextensions`, and `version-range` under Artistic-2.0.
+Redistributable builds retain their copyright notices, the complete
+Artistic-2.0 text under `resources/compliance/licenses/`, and verbatim source
+packages referenced by `SOURCE-MANIFEST.json`.
 
 ## Generating a complete license manifest
 To validate installed package notices without downloading corresponding source:

--- a/common/ipc.ts
+++ b/common/ipc.ts
@@ -2,6 +2,7 @@ import type { Analysis, AnalysisFeedback, AnalysisStep, Confidence } from "./ana
 import type { AutomationPlan, BuiltAutomation } from "./automation";
 import type { MicrophoneDevice } from "./microphone";
 import type { NarrationLanguage } from "./narration";
+import type { SensitiveReport } from "./sensitive";
 import type {
   BuiltSkill,
   SkillArchitecture,
@@ -9,6 +10,14 @@ import type {
   TargetPlacement,
 } from "./skill";
 import type { RecorderState } from "./types";
+
+export type {
+  SensitiveCategory,
+  SensitiveFinding,
+  SensitiveReport,
+  SensitiveSeverity,
+  SensitiveSource,
+} from "./sensitive";
 
 /** The last completed session — the one that can be analyzed. */
 export interface LastSession {
@@ -104,6 +113,40 @@ export interface AnalyzeProgress {
 export interface AnalyzeResult {
   ok: boolean;
   analysis?: Analysis;
+  error?: string;
+  /**
+   * Present when the on-device pre-send scan redacted potentially sensitive
+   * details before the session was sent to GitHub Copilot — masked values in the
+   * captured text, plus a count of on-screen regions blurred in frames. This is
+   * purely informational — the analysis still ran and `ok` is unaffected. The
+   * report carries only masked values + short redacted context, never raw values,
+   * so the renderer can show a non-blocking "Redacted N details" summary.
+   */
+  review?: SensitiveReport;
+}
+
+/** The on-device model asset behind "Advanced protection". */
+export type SensitiveModelState = "missing" | "downloading" | "ready" | "error";
+
+/**
+ * Status of the "Advanced protection" layer (on-device frame OCR). The persisted
+ * `enabled` opt-out is independent of whether the model file is downloaded: a user
+ * can turn it off while keeping the cache, or have it on while a download is still
+ * in flight (in which case scans still mask the outgoing text and the frame-blur
+ * layer joins once the model is ready).
+ */
+export interface SensitiveModelStatus {
+  /** Persisted user opt-in. */
+  enabled: boolean;
+  /** Tesseract OCR language data (for frame text detection). */
+  ocr: SensitiveModelState;
+  /** Download progress 0–100 while the OCR asset is downloading. */
+  progress: number | null;
+  error: string | null;
+}
+
+export interface SensitiveModelActionResult {
+  ok: boolean;
   error?: string;
 }
 
@@ -375,6 +418,11 @@ export const IPC = {
   narrationDownload: "narration:download",
   narrationTranscribe: "narration:transcribe",
   narrationStatusChanged: "narration:status-changed",
+  sensitiveModelStatus: "sensitive:status",
+  sensitiveSetAdvanced: "sensitive:set-advanced",
+  sensitiveDownloadModels: "sensitive:download-models",
+  sensitiveStatusChanged: "sensitive:status-changed",
+  sensitiveGetReport: "sensitive:get-report",
   analyze: "analyze:start",
   analyzeFeedback: "analyze:feedback",
   getAnalysis: "analyze:get",
@@ -399,6 +447,7 @@ export const IPC = {
   openLibrary: "ui:open-library",
   closeLibrary: "ui:close-library",
   recordingControlsExpanded: "ui:recording-controls-expanded",
+  fitRecorderHeight: "ui:fit-recorder-height",
 } as const;
 
 /** Shape exposed on `window.skillRecorder` by the preload bridge. */
@@ -432,7 +481,25 @@ export interface SkillRecorderApi {
   downloadNarrationModel(): Promise<NarrationActionResult>;
   transcribeNarration(sessionId: string): Promise<NarrationActionResult>;
   onNarrationStatusChanged(cb: (status: NarrationStatus) => void): () => void;
-  /** Run the Copilot describer on a session (defaults to the last completed one). */
+  /** Current status of the "Advanced protection" model (on-device frame OCR). */
+  sensitiveModelStatus(): Promise<SensitiveModelStatus>;
+  /** Toggle "Advanced protection". Enabling persists the opt-in and provisions the
+   *  model (warming from cache when present, else fetching it in the background);
+   *  disabling stops applying the model but keeps the cache. */
+  setAdvancedProtection(enabled: boolean): Promise<SensitiveModelActionResult>;
+  /** Download the on-device OCR data the Advanced layer needs and warm the engine.
+   *  The deliberate "download" action, mirroring the voice model — safe to call
+   *  repeatedly. */
+  downloadSensitiveModels(): Promise<SensitiveModelActionResult>;
+  onSensitiveModelStatusChanged(cb: (status: SensitiveModelStatus) => void): () => void;
+  /** Load the persisted redaction summary for a session, if any. Lets the review
+   *  panel rehydrate when an already-analyzed session is reopened (the live `review`
+   *  from {@link analyze} is transient). Contains only masked values + counts. */
+  getSensitiveReport(sessionId: string): Promise<SensitiveReport | null>;
+  /** Run the Copilot describer on a session (defaults to the last completed one).
+   *  Runs an on-device sensitive-detail scan first and redacts any flagged values
+   *  from the text before it is sent — non-blocking; the analysis always proceeds
+   *  and any redaction is reported back in `review`. */
   analyze(sessionId?: string): Promise<AnalyzeResult>;
   /** Send NL feedback and re-analyze in the same multi-turn session. */
   analyzeFeedback(input: AnalysisFeedbackInput): Promise<AnalyzeResult>;
@@ -495,4 +562,7 @@ export interface SkillRecorderApi {
   closeLibrary(): Promise<void>;
   /** Resize the recording-controls window while an overlay panel is visible. */
   setRecordingControlsExpanded(expanded: boolean): Promise<void>;
+  /** Fit the compact recorder window to its rendered content height (fire-and-forget)
+   *  so the fixed-width HUD never shows dead space or clips a revealed row. */
+  fitRecorderHeight(height: number): void;
 }

--- a/common/sensitive.test.ts
+++ b/common/sensitive.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  luhnValid,
+  maskValue,
+  redactText,
+  redactedSnippet,
+  resolveOverlaps,
+  scanStructuredPii,
+  type SensitiveCategory,
+  type SensitiveMatch,
+} from "./sensitive";
+
+/** Categories present in a structured-PII scan result. */
+function categories(text: string): SensitiveCategory[] {
+  return scanStructuredPii(text).map((m) => m.category);
+}
+
+test("flags emails, valid cards, SSNs, and phone numbers", () => {
+  assert.ok(categories("mail me at jane.doe@example.com please").includes("email"));
+  // Visa test number (passes Luhn).
+  assert.ok(categories("card 4111 1111 1111 1111 expires soon").includes("credit-card"));
+  assert.ok(categories("ssn 123-45-6789 on file").includes("ssn"));
+  assert.ok(categories("call 415-555-0132 today").includes("phone"));
+  assert.ok(categories("ring +1 415 555 0132 now").includes("phone"));
+});
+
+test("credit-card detector rejects non-Luhn digit runs and bare numbers", () => {
+  assert.ok(!categories("order 4111 1111 1111 1112 shipped").includes("credit-card"));
+  assert.ok(!categories("build 1234567890 completed").includes("credit-card"));
+});
+
+test("ssn detector rejects invalid area/group/serial", () => {
+  assert.ok(!categories("000-45-6789").includes("ssn"));
+  assert.ok(!categories("666-45-6789").includes("ssn"));
+  assert.ok(!categories("900-45-6789").includes("ssn"));
+  assert.ok(!categories("123-00-6789").includes("ssn"));
+  assert.ok(!categories("123-45-0000").includes("ssn"));
+});
+
+test("phone detector requires grouping and ignores bare digit runs", () => {
+  assert.ok(!categories("build 4155550132 completed").includes("phone"));
+  assert.ok(!categories("the meeting is at 3pm in room 204").includes("phone"));
+});
+
+test("phone after a number ending in 1 is still detected (no country-code latch)", () => {
+  // The optional leading "1" country code must not swallow the trailing "1" of a
+  // preceding number, which would grow the phone match to overlap that number and
+  // get dropped by resolveOverlaps — silently leaking the phone.
+  const hits = scanStructuredPii("Noah Kim 345-67-8901 (650) 555-0188");
+  assert.deepEqual(
+    hits.map((m) => `${m.category}:${m.value}`).sort(),
+    ["phone:(650) 555-0188", "ssn:345-67-8901"],
+  );
+});
+
+test("does not flag ordinary prose, URLs, or commit hashes", () => {
+  assert.equal(scanStructuredPii("Opened the quarterly planning doc and reviewed the roadmap.").length, 0);
+  assert.equal(scanStructuredPii("Visited https://github.com/microsoft/skill-recorder/issues").length, 0);
+  assert.equal(scanStructuredPii("git checkout 9c1e6f2a4b7d8e0f1a2b3c4d5e6f7a8b9c0d1e2f").length, 0);
+});
+
+test("overlapping matches collapse to the strongest single finding", () => {
+  const higher: SensitiveMatch = {
+    category: "api-key",
+    label: "GitHub token",
+    severity: "high",
+    value: "ghp_secretvalue",
+    start: 6,
+    end: 21,
+    rank: 90,
+  };
+  const lower: SensitiveMatch = {
+    category: "password",
+    label: "Assignment",
+    severity: "medium",
+    value: "token=ghp_secretvalue",
+    start: 0,
+    end: 21,
+    rank: 30,
+  };
+  const kept = resolveOverlaps([lower, higher]);
+  assert.equal(kept.length, 1);
+  assert.equal(kept[0].label, "GitHub token");
+});
+
+test("maskValue never returns the original and hides the middle", () => {
+  const secret = "ghp_ABCDEFGHIJKLMNOP";
+  const masked = maskValue(secret);
+  assert.notEqual(masked, secret);
+  assert.ok(!masked.includes("CDEFGHIJKLMN"));
+  assert.ok(masked.includes("••••"));
+  assert.equal(maskValue("short"), "••••");
+  assert.equal(maskValue(""), "");
+});
+
+test("redactText masks every match in place and leaves the rest intact", () => {
+  const text = "email jane@example.com and card 4111 1111 1111 1111 today";
+  const matches = scanStructuredPii(text);
+  const redacted = redactText(text, matches);
+  assert.ok(redacted.startsWith("email "));
+  assert.ok(!redacted.includes("jane@example.com"));
+  assert.ok(!redacted.includes("4111 1111 1111 1111"));
+  assert.ok(redacted.includes("••••"));
+});
+
+test("redactedSnippet returns trimmed, masked context", () => {
+  const text = "contact the vendor at billing@corp.example.com before the deadline";
+  const [match] = scanStructuredPii(text);
+  const snippet = redactedSnippet(text, match);
+  assert.ok(!snippet.includes("billing@corp.example.com"));
+  assert.ok(snippet.includes("••••"));
+});
+
+test("redactedSnippet masks a second value adjacent to the focus match", () => {
+  // Two emails within one snippet window: the focus match's snippet must not leak
+  // the neighbor raw, so callers that pass the full match list stay redacted.
+  const text = "primary alice@example.com and backup bob@example.com on file";
+  const matches = scanStructuredPii(text);
+  assert.equal(matches.length, 2);
+  const snippet = redactedSnippet(text, matches[0], matches);
+  assert.ok(!snippet.includes("alice@example.com"));
+  assert.ok(!snippet.includes("bob@example.com"), "neighbor value must not leak raw");
+});
+
+test("Luhn helper behaves", () => {
+  assert.ok(luhnValid("4111111111111111"));
+  assert.ok(!luhnValid("4111111111111112"));
+  assert.ok(!luhnValid("abcd"));
+});

--- a/common/sensitive.ts
+++ b/common/sensitive.ts
@@ -1,0 +1,340 @@
+// Renderer-safe types, masking, and structured-PII detectors for the on-device
+// pre-send scan Skill Recorder runs before it sends captured text to GitHub
+// Copilot on Analyze (window/document titles, URLs, clipboard previews, terminal
+// commands, markers, and voice narration).
+//
+// This module is pure and dependency-free so it can run in either process and be
+// unit-tested in isolation. It owns only the *structured* PII detectors (email,
+// payment card, SSN, phone) — high-precision, checksum-validated where possible.
+// The other detection layer lives in the Electron main process because it needs a
+// Node-only dep: secrets/credentials via `@secretlint/core`
+// (electron/sensitive/secrets.ts). Both layers emit {@link SensitiveMatch}es and
+// are merged with {@link resolveOverlaps}. Nothing here ever emits or stores a raw
+// value on its own; callers use {@link maskValue} / {@link redactText}.
+
+/** The kind of sensitive detail a match represents. */
+export type SensitiveCategory =
+  // Secrets / credentials (secretlint, main process).
+  | "private-key"
+  | "api-key"
+  | "jwt"
+  | "password"
+  // Structured PII (this module).
+  | "email"
+  | "credit-card"
+  | "ssn"
+  | "phone";
+
+/** How strongly a finding should be treated as a real leak. */
+export type SensitiveSeverity = "high" | "medium" | "low";
+
+/** Where in a recording a finding was captured (its provenance). */
+export type SensitiveSource =
+  | "window-title"
+  | "url"
+  | "command"
+  | "clipboard"
+  | "note"
+  | "narration"
+  | "frame"
+  // A captured field with no dedicated provenance (e.g. a terminal cwd, a window
+  // path/host). Scanned for completeness so detection covers the whole payload.
+  | "other";
+
+/** One raw detector hit inside a single string. Carries the matched value in
+ *  memory only; never persist or display it directly — mask it first. */
+export interface SensitiveMatch {
+  category: SensitiveCategory;
+  /** Human label for the UI, e.g. "GitHub token" or "Email address". */
+  label: string;
+  severity: SensitiveSeverity;
+  /** The matched substring (in-memory only). */
+  value: string;
+  /** Half-open [start, end) offsets of {@link value} within the scanned string. */
+  start: number;
+  end: number;
+  /** Priority when two matches overlap the same span (specific/validated > generic).
+   *  Secrets rank highest, then structured PII. */
+  rank: number;
+}
+
+const SEVERITY_RANK: Record<SensitiveSeverity, number> = { high: 3, medium: 2, low: 1 };
+
+/** A regex-backed detector spec for structured PII. */
+interface DetectorSpec {
+  category: SensitiveCategory;
+  label: string;
+  severity: SensitiveSeverity;
+  /** Higher wins when two detectors overlap the same span (specific > generic). */
+  rank: number;
+  pattern: RegExp;
+  /** Capture-group index holding the sensitive value; defaults to the whole match. */
+  valueGroup?: number;
+  /** Extra validation (e.g. Luhn); return false to reject a candidate. */
+  accept?: (value: string, match: RegExpExecArray) => boolean;
+}
+
+/** Structured-PII detectors. High precision on purpose: each either has a
+ *  distinctive shape or is checksum/format-validated, so ordinary prose, hashes,
+ *  version strings, and bare digit runs don't trip it. */
+const STRUCTURED_PII: DetectorSpec[] = [
+  {
+    category: "credit-card",
+    label: "Payment card number",
+    severity: "high",
+    rank: 55,
+    // 13–19 digits with optional single space/dash separators, anchored to a digit
+    // at both ends so a trailing separator is never captured into the value.
+    pattern: /\b\d(?:[ -]?\d){12,18}\b/g,
+    accept: (value) => {
+      const digits = value.replace(/[ -]/g, "");
+      return digits.length >= 13 && digits.length <= 19 && luhnValid(digits);
+    },
+  },
+  {
+    category: "ssn",
+    label: "US Social Security number",
+    severity: "high",
+    rank: 55,
+    pattern: /\b(\d{3})-(\d{2})-(\d{4})\b/g,
+    accept: (_value, match) => {
+      const area = match[1];
+      const group = match[2];
+      const serial = match[3];
+      return (
+        area !== "000" &&
+        area !== "666" &&
+        area[0] !== "9" &&
+        group !== "00" &&
+        serial !== "0000"
+      );
+    },
+  },
+  {
+    category: "phone",
+    label: "Phone number",
+    severity: "low",
+    rank: 45,
+    // North-American grouped format (3-3-4) with a required separator between
+    // groups, so a bare 10-digit run — or a card/SSN — doesn't match. An optional
+    // country code (+1 / 1) may lead it. The leading `(?<!\d)` stops that optional
+    // "1" from latching onto the trailing digit of a preceding number (e.g. an SSN
+    // ending in "1" right before the phone): without it the match would grow to
+    // overlap that number and get dropped by resolveOverlaps, silently leaking the
+    // phone.
+    pattern: /(?<!\d)(?:\+?1[\s.-]?)?(?:\(\d{3}\)[\s.-]?|\d{3}[\s.-])\d{3}[\s.-]\d{4}(?!\d)/g,
+    accept: (value) => {
+      const digits = value.replace(/\D/g, "");
+      return digits.length === 10 || (digits.length === 11 && digits.startsWith("1"));
+    },
+  },
+  {
+    category: "phone",
+    label: "Phone number",
+    severity: "low",
+    rank: 45,
+    // International E.164: must start with "+" and hold 8–15 digits total, with
+    // optional spaces/dots/dashes as visual grouping.
+    pattern: /\+\d(?:[\s.-]?\d){7,14}(?!\d)/g,
+    accept: (value) => {
+      const digits = value.replace(/\D/g, "");
+      return digits.length >= 8 && digits.length <= 15;
+    },
+  },
+  {
+    category: "email",
+    label: "Email address",
+    severity: "medium",
+    rank: 40,
+    pattern: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g,
+  },
+];
+
+/** Luhn checksum validation for a digit string (payment-card sanity check). */
+export function luhnValid(digits: string): boolean {
+  if (!/^\d+$/.test(digits)) return false;
+  let sum = 0;
+  let double = false;
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let d = digits.charCodeAt(i) - 48;
+    if (double) {
+      d *= 2;
+      if (d > 9) d -= 9;
+    }
+    sum += d;
+    double = !double;
+  }
+  return sum % 10 === 0;
+}
+
+function detectorMatches(text: string, specs: DetectorSpec[]): SensitiveMatch[] {
+  const out: SensitiveMatch[] = [];
+  for (const spec of specs) {
+    // Fresh lastIndex per scan; `pattern` is a module-level /g regex.
+    spec.pattern.lastIndex = 0;
+    for (let m = spec.pattern.exec(text); m; m = spec.pattern.exec(text)) {
+      const value = spec.valueGroup != null ? m[spec.valueGroup] : m[0];
+      if (!value) continue;
+      if (spec.accept && !spec.accept(value, m)) continue;
+      const offset = spec.valueGroup != null ? m[0].indexOf(value) : 0;
+      const start = m.index + (offset < 0 ? 0 : offset);
+      out.push({
+        category: spec.category,
+        label: spec.label,
+        severity: spec.severity,
+        value,
+        start,
+        end: start + value.length,
+        rank: spec.rank,
+      });
+      // Guard against zero-length matches spinning forever.
+      if (m.index === spec.pattern.lastIndex) spec.pattern.lastIndex++;
+    }
+  }
+  return out;
+}
+
+/** Drop matches fully or partially overlapping a higher-priority match, keeping
+ *  the strongest (severity, then rank, then length) for each region. Works across
+ *  every detection layer (secrets, structured PII, frame heuristics). */
+export function resolveOverlaps(matches: SensitiveMatch[]): SensitiveMatch[] {
+  const ordered = [...matches].sort((a, b) => {
+    const sev = SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity];
+    if (sev !== 0) return sev;
+    const rank = b.rank - a.rank;
+    if (rank !== 0) return rank;
+    const len = b.end - b.start - (a.end - a.start);
+    if (len !== 0) return len;
+    return a.start - b.start;
+  });
+  const kept: SensitiveMatch[] = [];
+  for (const m of ordered) {
+    if (kept.some((k) => m.start < k.end && k.start < m.end)) continue;
+    kept.push(m);
+  }
+  return kept.sort((a, b) => a.start - b.start);
+}
+
+/**
+ * Scan a single string for structured PII (email, payment card, SSN, phone) and
+ * return every distinct match, ordered by position with overlaps resolved. Pure
+ * and deterministic. Secrets are detected by the main-process secretlint layer and
+ * merged separately.
+ */
+export function scanStructuredPii(text: string): SensitiveMatch[] {
+  if (!text) return [];
+  return resolveOverlaps(detectorMatches(text, STRUCTURED_PII));
+}
+
+/**
+ * Mask a sensitive value for display or storage: reveals at most a few leading /
+ * trailing characters and hides the rest behind a fixed-width mask (so the true
+ * length isn't leaked). Short values are masked entirely.
+ */
+export function maskValue(value: string): string {
+  const MASK = "••••";
+  if (!value) return "";
+  if (value.length <= 6) return MASK;
+  const head = value.slice(0, 2);
+  const tail = value.slice(-2);
+  return `${head}${MASK}${tail}`;
+}
+
+/** Replace every match's span in `text` with a mask, leaving the rest intact. */
+export function redactText(text: string, matches: SensitiveMatch[]): string {
+  if (matches.length === 0) return text;
+  const ordered = [...matches].sort((a, b) => a.start - b.start);
+  let out = "";
+  let cursor = 0;
+  for (const m of ordered) {
+    if (m.start < cursor) continue; // skip any residual overlap
+    out += text.slice(cursor, m.start) + maskValue(m.value);
+    cursor = m.end;
+  }
+  return out + text.slice(cursor);
+}
+
+/**
+ * A short, already-redacted context window around a match — enough for the user
+ * to recognize where the detail came from without exposing the value itself.
+ *
+ * `all` should contain every match detected in `text`; each one that overlaps the
+ * window is masked, so an adjacent sensitive value never leaks raw through this
+ * snippet. It defaults to just the focus match to preserve callers that only have
+ * the one.
+ */
+export function redactedSnippet(
+  text: string,
+  match: SensitiveMatch,
+  all: SensitiveMatch[] = [match],
+  pad = 32,
+): string {
+  const from = Math.max(0, match.start - pad);
+  const to = Math.min(text.length, match.end + pad);
+  const slice = text.slice(from, to);
+  const local = all
+    .filter((m) => m.end > from && m.start < to)
+    .map((m) => ({
+      ...m,
+      start: Math.max(0, m.start - from),
+      end: Math.min(slice.length, m.end - from),
+    }));
+  const redacted = redactText(slice, local).replace(/\s+/g, " ").trim();
+  return `${from > 0 ? "…" : ""}${redacted}${to < text.length ? "…" : ""}`;
+}
+
+/* --- Session-level report shapes (shared with the IPC layer) --------------- */
+
+/** One deduplicated sensitive detail found across a recording. Safe to persist
+ *  and display — it carries only masked / redacted text, never the raw value. */
+export interface SensitiveFinding {
+  category: SensitiveCategory;
+  label: string;
+  severity: SensitiveSeverity;
+  /** Where it was captured (window title, url, clipboard, command, note, voice). */
+  source: SensitiveSource;
+  /** Masked form of the detected value (e.g. `gh••••cd`). */
+  redactedValue: string;
+  /** Short redacted context, e.g. `…api_key=gh••••cd npm install…`. */
+  snippet: string;
+  /** ms since the recording started, for context; null when unknown. */
+  atMs: number | null;
+  /** How many times this exact value+source pair was seen. */
+  occurrences: number;
+}
+
+/** The result of scanning one recording for sensitive details before Analyze. */
+export interface SensitiveReport {
+  sessionId: string;
+  scannedAt: number;
+  totalFindings: number;
+  highSeverityCount: number;
+  counts: Partial<Record<SensitiveCategory, number>>;
+  findings: SensitiveFinding[];
+  /** What was blurred in screen images during the analyze run. Filled in after
+   *  frames are processed; absent when nothing on-screen was covered. Images are
+   *  summarized as counts only — the on-screen text itself is never retained. */
+  images?: { framesBlurred: number; regionsBlurred: number };
+}
+
+/** Human label for a finding's provenance. */
+export function sourceLabel(source: SensitiveSource): string {
+  switch (source) {
+    case "window-title":
+      return "Window title";
+    case "url":
+      return "URL";
+    case "command":
+      return "Terminal command";
+    case "clipboard":
+      return "Clipboard";
+    case "note":
+      return "Note";
+    case "narration":
+      return "Voice narration";
+    case "frame":
+      return "On-screen text";
+    case "other":
+      return "Other captured text";
+  }
+}

--- a/electron/describer/describer.ts
+++ b/electron/describer/describer.ts
@@ -18,7 +18,7 @@ import { createLogger } from "../logger";
 import { copilotConnectionOption, withStartupTimeout } from "../copilot-cli-path";
 import { sessionsRoot, sessionDir, isValidSessionId } from "../recorder/session-store";
 import { DESCRIBER_INSTRUCTIONS } from "./instructions";
-import { createDescriberTools } from "./tools";
+import { createDescriberTools, type RedactionContext } from "./tools";
 
 const log = createLogger("Describer");
 
@@ -55,6 +55,8 @@ interface LiveSession {
   feedbackLog: Analysis["feedbackLog"];
   /** Mutable capture slot the `submit_analysis` tool writes into. */
   holder: { submission: AnalysisSubmission | undefined };
+  /** Mutable redaction slot; set per turn so tools mask outgoing data. */
+  redaction: { current: RedactionContext | null };
 }
 
 function readJson<T>(file: string): T | null {
@@ -94,13 +96,14 @@ export class Describer {
   constructor(private readonly emitProgress: (p: AnalyzeProgress) => void) {}
 
   /** First pass: reconstruct the session from scratch. */
-  async analyze(sessionId: string): Promise<Analysis> {
+  async analyze(sessionId: string, redaction?: RedactionContext): Promise<Analysis> {
     if (this.active.has(sessionId)) throw new Error("An analysis is already running for this session.");
     this.active.add(sessionId);
     try {
       this.emit(sessionId, "start", "Starting analysis…");
       await this.disposeLive(sessionId); // fresh conversation each explicit analyze
       const live = await this.createLive(sessionId);
+      live.redaction.current = redaction ?? null;
       return await this.runTurn(live, KICKOFF_PROMPT);
     } finally {
       this.active.delete(sessionId);
@@ -108,12 +111,13 @@ export class Describer {
   }
 
   /** Later pass: fold in NL feedback and revise holistically. */
-  async feedback(sessionId: string, fb: AnalysisFeedback): Promise<Analysis> {
+  async feedback(sessionId: string, fb: AnalysisFeedback, redaction?: RedactionContext): Promise<Analysis> {
     if (this.active.has(sessionId)) throw new Error("An analysis is already running for this session.");
     this.active.add(sessionId);
     try {
       this.emit(sessionId, "start", "Re-analyzing with your feedback…");
       const live = this.live.get(sessionId) ?? (await this.createLive(sessionId));
+      live.redaction.current = redaction ?? null;
       const prior = loadPersistedAnalysis(sessionId);
       // The feedback round is recorded in runTurn only after it produces a
       // revision, so a failed turn never leaves a phantom log entry.
@@ -239,11 +243,13 @@ export class Describer {
 
     const extractor = buildExtractor(dir);
     const holder: LiveSession["holder"] = { submission: undefined };
+    const redaction: LiveSession["redaction"] = { current: null };
 
     const tools = createDescriberTools({
       sessionDir: dir,
       startedAt: meta.startedAt,
       extractor,
+      redaction,
       onProgress: (m) => this.emit(sessionId, "working", m),
       onSubmit: (s) => {
         holder.submission = s;
@@ -277,6 +283,7 @@ export class Describer {
       revision: prior?.revision ?? 0,
       feedbackLog: prior?.feedbackLog ?? [],
       holder,
+      redaction,
     };
     this.live.set(sessionId, live);
     this.evictOverflow(sessionId);

--- a/electron/describer/tools.ts
+++ b/electron/describer/tools.ts
@@ -10,9 +10,19 @@ import { NARRATION_FILE, type NarrationTranscript } from "../../common/narration
 import type { RecEvent } from "../../common/types";
 import { readEvents } from "../frames/correlate";
 import type { FrameExtractor } from "../frames/extractor";
+import type { FrameRedactor } from "../sensitive/frame-redact";
 import { createLogger } from "../logger";
 
 const log = createLogger("Describer/tools");
+
+/** Redaction applied to a session's data before it leaves the machine. Threaded
+ *  through a mutable slot so the same live tools pick up fresh values each turn. */
+export interface RedactionContext {
+  /** Mask every detected raw value in an outgoing text string. */
+  redactText: (text: string) => string;
+  /** Frame OCR + blur policy for get_frames, or null to serve frames unchanged. */
+  frameRedactor: FrameRedactor | null;
+}
 
 /** Everything a session's tools are bound to. */
 export interface ToolContext {
@@ -21,6 +31,8 @@ export interface ToolContext {
   startedAt: number;
   /** Frame service, or null when the session has no video. */
   extractor: FrameExtractor | null;
+  /** Mutable redaction slot; `current` is set per turn (null = no redaction). */
+  redaction: { current: RedactionContext | null };
   /** Streamed to the UI as the agent works. */
   onProgress?: (message: string) => void;
   /** Called when the agent submits a (validated) analysis. */
@@ -66,6 +78,8 @@ function readNarration(sessionDir: string): NarrationTranscript | null {
 export function createDescriberTools(ctx: ToolContext): Tool[] {
   const { sessionDir, startedAt, extractor, onSubmit } = ctx;
   const progress = (m: string) => ctx.onProgress?.(m);
+  // Mask detected sensitive values in every outgoing text field (null slot = no-op).
+  const redact = (s: string): string => ctx.redaction.current?.redactText(s) ?? s;
   const rel = (epoch: number) => Math.round(epoch - startedAt);
   const abs = (atMs: number) => startedAt + atMs;
   const sec = (atMs: number) => (atMs / 1000).toFixed(1);
@@ -105,7 +119,7 @@ export function createDescriberTools(ctx: ToolContext): Tool[] {
           summary: s.summary,
         })),
       };
-      return JSON.stringify(view, null, 2);
+      return redact(JSON.stringify(view, null, 2));
     },
   };
 
@@ -151,17 +165,19 @@ export function createDescriberTools(ctx: ToolContext): Tool[] {
       // of rows in one tool result. When truncated, tell the agent how to narrow.
       const rows = all.slice(0, MAX_EVENTS);
       const truncated = all.length > rows.length;
-      return JSON.stringify(
-        {
-          count: rows.length,
-          total: all.length,
-          ...(truncated
-            ? { truncated: true, note: `Showing the first ${MAX_EVENTS} of ${all.length} events. Narrow with fromMs/toMs or filter by types.` }
-            : {}),
-          events: rows,
-        },
-        null,
-        2,
+      return redact(
+        JSON.stringify(
+          {
+            count: rows.length,
+            total: all.length,
+            ...(truncated
+              ? { truncated: true, note: `Showing the first ${MAX_EVENTS} of ${all.length} events. Narrow with fromMs/toMs or filter by types.` }
+              : {}),
+            events: rows,
+          },
+          null,
+          2,
+        ),
       );
     },
   };
@@ -251,13 +267,41 @@ export function createDescriberTools(ctx: ToolContext): Tool[] {
         for (let i = 0; i < MAX_IMAGES_PER_CALL; i++) picks.push(inWindow[Math.round(i * stride)]);
       }
 
+      // Advanced protection: frames are the only image channel, so on-screen text
+      // must be OCR'd + blurred before any pixels are sent. Policy:
+      //   inactive          → serve raw frames (baseline behaviour).
+      //   active, not ready  → WITHHOLD frames (assets still loading) — never raw.
+      //   active, ready      → blur detected regions per frame; withhold on failure.
+      const redactor = ctx.redaction.current?.frameRedactor ?? null;
+      const protect = redactor?.active ?? false;
+      if (redactor?.active && !redactor.ready) {
+        return {
+          textResultForLlm:
+            "Advanced protection is on but the on-device OCR model could not be made ready (it may still be downloading, or the download failed, for example when offline), so screen frames are being withheld for this window to avoid sending unredacted on-screen text. Proceeding on events and narration; frames become available once the model is ready.",
+          resultType: "success",
+        };
+      }
+
       const binaryResultsForLlm: { data: string; mimeType: string; type: "image"; description?: string }[] = [];
+      let withheld = 0;
       for (const f of picks) {
         const file = path.join(sessionDir, "frames", f.file);
         if (!existsSync(file)) continue;
         try {
+          let data: string;
+          if (protect && redactor) {
+            const buf = await redactor.redactFrame(file);
+            if (!buf) {
+              // Redaction failed for this frame — withhold it rather than serve raw.
+              withheld++;
+              continue;
+            }
+            data = buf.toString("base64");
+          } else {
+            data = readFileSync(file).toString("base64");
+          }
           binaryResultsForLlm.push({
-            data: readFileSync(file).toString("base64"),
+            data,
             mimeType: "image/jpeg",
             type: "image",
             description: `${sec(rel(f.tMs))}s (${f.source}) ${f.file}`,
@@ -268,9 +312,12 @@ export function createDescriberTools(ctx: ToolContext): Tool[] {
       }
       const listing = inWindow.map((f) => `- ${sec(rel(f.tMs))}s ${f.file} (${f.source})`).join("\n");
       progress(`Attached ${binaryResultsForLlm.length} frame image(s) from ${sec(fromMs)}–${sec(toMs)}s.`);
+      const protectNote = protect
+        ? ` On-device Advanced protection blurred any detected sensitive on-screen text${withheld ? `; ${withheld} frame(s) were withheld because redaction failed` : ""}.`
+        : "";
       return {
         textResultForLlm:
-          `Frames in ${sec(fromMs)}–${sec(toMs)}s (${inWindow.length} total, ${binaryResultsForLlm.length} shown as images):\n${listing}`,
+          `Frames in ${sec(fromMs)}–${sec(toMs)}s (${inWindow.length} total, ${binaryResultsForLlm.length} shown as images):\n${listing}${protectNote}`,
         binaryResultsForLlm,
         resultType: "success",
       };
@@ -305,7 +352,7 @@ export function createDescriberTools(ctx: ToolContext): Tool[] {
       if (lines.length === 0) {
         return `No narration lines match “${args.query}”. Call get_narration with no query to read the whole transcript.`;
       }
-      return lines.join("\n");
+      return redact(lines.join("\n"));
     },
   };
 

--- a/electron/ipc.ts
+++ b/electron/ipc.ts
@@ -27,17 +27,26 @@ import type {
 import { IPC } from "../common/ipc";
 import type { AutomationPlan } from "../common/automation";
 import type { NarrationLanguage } from "../common/narration";
+import type { SensitiveReport } from "../common/sensitive";
 import type { SkillPlan } from "../common/skill";
 import { AutomationBuilder, loadPersistedAutomation } from "./automationbuilder/builder";
 import { openCopilotSignIn } from "./copilot-signin";
 import { buildDebugInfo, writeDebugBundle } from "./debug-bundle";
 import { Describer, loadPersistedAnalysis } from "./describer/describer";
+import type { RedactionContext } from "./describer/tools";
 import { runDoctor } from "./doctor";
 import { createLogger } from "./logger";
 import type { AudioRecorder } from "./audio/recorder";
 import type { NarrationManager } from "./narration/manager";
 import type { RecorderController } from "./recorder/controller";
 import { isValidSessionId } from "./recorder/session-store";
+import {
+  INACTIVE_FRAME_REDACTOR,
+  OcrFrameRedactor,
+  WITHHOLD_FRAME_REDACTOR,
+} from "./sensitive/frame-redact";
+import type { SensitiveModelManager } from "./sensitive/model-manager";
+import { buildRedactor, loadSensitiveReport, saveSensitiveReport, scanSession } from "./sensitive/scanner";
 import { deleteSession, listSessions } from "./sessions";
 import { loadPersistedSkill, SkillBuilder, type SkillTarget } from "./skillbuilder/builder";
 
@@ -51,6 +60,7 @@ export function registerIpc(
   automationBuilder: AutomationBuilder,
   narration: NarrationManager,
   microphones: AudioRecorder,
+  sensitiveModels: SensitiveModelManager,
 ): void {
   ipcMain.handle(IPC.stop, () => recorder.stop());
   ipcMain.handle(IPC.discard, () => recorder.discard());
@@ -129,35 +139,117 @@ export function registerIpc(
     return dir ? path.basename(dir) : null;
   };
 
-  ipcMain.handle(IPC.analyze, async (_event, sessionId?: string): Promise<AnalyzeResult> => {
-    const id = resolveSessionId(sessionId);
-    if (!id) return { ok: false, error: "No completed session to analyze yet." };
-    if (!isValidSessionId(id)) return { ok: false, error: "Unknown session." };
-    // Transcribe any recorded voice first so analysis never silently runs without
-    // the user's spoken intent. Downloads the model on first use. Best-effort: a
-    // failure here falls through to analyzing without voice (the error is surfaced
-    // via the narration status affordance and the audio stays saved).
-    await narration.ensureTranscribedForAnalysis(id);
-    try {
-      const analysis = await describer.analyze(id);
-      return { ok: true, analysis };
-    } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      log.warn("analyze failed:", error);
-      return { ok: false, error };
-    }
+  ipcMain.handle(IPC.sensitiveModelStatus, () => sensitiveModels.status());
+  ipcMain.handle(IPC.sensitiveSetAdvanced, (_event, enabled: boolean) => {
+    if (typeof enabled !== "boolean") return { ok: false, error: "Invalid preference." };
+    return sensitiveModels.setAdvanced(enabled);
   });
+  ipcMain.handle(IPC.sensitiveDownloadModels, () => sensitiveModels.downloadModels());
+
+  /**
+   * Run the on-device pre-send scan and build the redaction context threaded into
+   * the describer. Gated by the single protection opt-out (on by default): when it
+   * is on, the text layers (secretlint + structured PII, which need no model) mask
+   * the outgoing text and the frame-OCR layer blurs on-screen matches once its model
+   * is ready; when the user has opted out, nothing is scanned and raw text + frames
+   * are sent. Non-blocking: a scan failure still lets analysis run — text goes out
+   * unmasked but frames are withheld so an error can't leak on-screen secrets.
+   */
+  const buildRedaction = async (
+    sessionId: string,
+  ): Promise<{ redaction: RedactionContext; report?: SensitiveReport }> => {
+    // Protection is a single opt-out covering BOTH layers: masking secrets/PII in the
+    // outgoing text AND blurring them in screen images. On by default; when the user
+    // turns it off they've accepted sending the recording unredacted (better analysis
+    // fidelity, no safety net), so we scan nothing and serve raw text + frames.
+    if (!sensitiveModels.isAdvancedEnabled()) {
+      return { redaction: { redactText: (t) => t, frameRedactor: INACTIVE_FRAME_REDACTOR } };
+    }
+    try {
+      const { report, values } = await scanSession(sessionId);
+      const redactText = buildRedactor(values);
+      // Blur on-screen matches in frames too. If the OCR model is still provisioning
+      // (typically a fresh first run) wait briefly for it rather than dropping frames;
+      // only withhold if it can't be made ready in time (so Analyze never hangs, e.g.
+      // offline).
+      await sensitiveModels.ensureReady();
+      const frameRedactor = new OcrFrameRedactor({ ocr: sensitiveModels.getOcr(), knownValues: values });
+      return { redaction: { redactText, frameRedactor }, report };
+    } catch (err) {
+      log.warn("sensitive scan failed; proceeding without text redaction:", err instanceof Error ? err.message : err);
+      // Protection is on but the scan threw: we have no values to mask text with, but we
+      // must NOT serve raw frames, so withhold them so a scan error can't leak on-screen
+      // secrets.
+      return {
+        redaction: { redactText: (t) => t, frameRedactor: WITHHOLD_FRAME_REDACTOR },
+      };
+    }
+  };
+
+  /**
+   * Fold the frame-blur tally (known only after the describer has pulled frames)
+   * into the pre-send text report, and decide whether there's anything worth
+   * surfacing. Returns undefined when protection was off/failed or nothing was
+   * hidden, so the UI shows a review only when it has something to say.
+   */
+  const summarizeProtection = (
+    report: SensitiveReport | undefined,
+    redaction: RedactionContext,
+  ): SensitiveReport | undefined => {
+    if (!report) return undefined;
+    const { framesBlurred, regionsBlurred } = redaction.frameRedactor?.stats ?? {
+      framesBlurred: 0,
+      regionsBlurred: 0,
+    };
+    const images = regionsBlurred > 0 ? { framesBlurred, regionsBlurred } : undefined;
+    if (report.totalFindings === 0 && !images) return undefined;
+    return images ? { ...report, images } : report;
+  };
+
+  ipcMain.handle(
+    IPC.analyze,
+    async (_event, sessionId?: string): Promise<AnalyzeResult> => {
+      const id = resolveSessionId(sessionId);
+      if (!id) return { ok: false, error: "No completed session to analyze yet." };
+      if (!isValidSessionId(id)) return { ok: false, error: "Unknown session." };
+      // Transcribe any recorded voice first so analysis never silently runs without
+      // the user's spoken intent. Downloads the model on first use. Best-effort: a
+      // failure here falls through to analyzing without voice (the error is surfaced
+      // via the narration status affordance and the audio stays saved).
+      await narration.ensureTranscribedForAnalysis(id);
+      // On-device pre-send redaction (non-blocking): mask secrets/credentials/PII in
+      // every outgoing text field — and, under Advanced protection, blur on-screen
+      // text in frames — before anything reaches GitHub Copilot. Analysis always
+      // proceeds; the (raw-value-free) report is returned purely for a UI summary.
+      const { redaction, report } = await buildRedaction(id);
+      try {
+        const analysis = await describer.analyze(id, redaction);
+        const review = summarizeProtection(report, redaction);
+        saveSensitiveReport(id, review);
+        return { ok: true, analysis, review };
+      } catch (err) {
+        const error = err instanceof Error ? err.message : String(err);
+        log.warn("analyze failed:", error);
+        return { ok: false, error };
+      }
+    },
+  );
 
   ipcMain.handle(
     IPC.analyzeFeedback,
     async (_event, input: AnalysisFeedbackInput): Promise<AnalyzeResult> => {
       if (!isValidSessionId(input?.sessionId)) return { ok: false, error: "Unknown session." };
+      // Re-scan + rebind the redactor so the feedback round stays masked too.
+      const { redaction, report } = await buildRedaction(input.sessionId);
       try {
-        const analysis = await describer.feedback(input.sessionId, {
-          overall: input.overall,
-          steps: input.steps ?? [],
-        });
-        return { ok: true, analysis };
+        const analysis = await describer.feedback(
+          input.sessionId,
+          { overall: input.overall, steps: input.steps ?? [] },
+          redaction,
+        );
+        const review = summarizeProtection(report, redaction);
+        saveSensitiveReport(input.sessionId, review);
+        return { ok: true, analysis, review };
       } catch (err) {
         const error = err instanceof Error ? err.message : String(err);
         log.warn("feedback failed:", error);
@@ -168,6 +260,10 @@ export function registerIpc(
 
   ipcMain.handle(IPC.getAnalysis, (_event, sessionId: string) =>
     isValidSessionId(sessionId) ? loadPersistedAnalysis(sessionId) : null,
+  );
+
+  ipcMain.handle(IPC.sensitiveGetReport, (_event, sessionId: string) =>
+    isValidSessionId(sessionId) ? loadSensitiveReport(sessionId) : null,
   );
 
   ipcMain.handle(IPC.updateAnalysis, async (_event, input: AnalysisEditInput): Promise<AnalyzeResult> => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -9,6 +9,7 @@ import { processSession } from "./pipeline";
 import { registerIpc } from "./ipc";
 import { createLogger } from "./logger";
 import { NarrationManager } from "./narration/manager";
+import { SensitiveModelManager } from "./sensitive/model-manager";
 import { RecorderController } from "./recorder/controller";
 import { RecordingPrivacySession } from "./recording-privacy";
 import { deleteSession } from "./sessions";
@@ -23,6 +24,7 @@ import {
   createLibraryWindow,
   createRecorderWindow,
   createRecordingControlsWindow,
+  fitRecorderHeight,
   redockLibrary,
   setRecordingControlsExpanded,
 } from "./window";
@@ -46,6 +48,9 @@ let quitTask: Promise<void> | null = null;
 const recordingPrivacy = new RecordingPrivacySession();
 const narration = new NarrationManager((status) =>
   broadcast(IPC.narrationStatusChanged, status),
+);
+const sensitiveModels = new SensitiveModelManager((status) =>
+  broadcast(IPC.sensitiveStatusChanged, status),
 );
 const microphones = new AudioRecorder((status) =>
   broadcast(IPC.microphoneSettingsChanged, status),
@@ -222,7 +227,9 @@ app.whenReady().then(async () => {
     automationBuilder,
     narration,
     microphones,
+    sensitiveModels,
   );
+  sensitiveModels.initialize();
   ipcMain.handle(IPC.start, () => requestStartRecording());
   ipcMain.handle(IPC.startConfirmed, () => startRecording());
   ipcMain.handle(IPC.recordingPrivacyReviewed, () => recordingPrivacy.markReviewed());
@@ -245,6 +252,18 @@ app.whenReady().then(async () => {
     }
     controlsExpanded = expanded;
     setRecordingControlsExpanded(win, expanded);
+  });
+  ipcMain.on(IPC.fitRecorderHeight, (event, height: unknown) => {
+    const win = recorderWindow;
+    if (
+      !win ||
+      win.isDestroyed() ||
+      event.sender !== win.webContents ||
+      typeof height !== "number"
+    ) {
+      return;
+    }
+    fitRecorderHeight(win, height);
   });
 
   recorder.onStatusChanged((status) => {
@@ -316,4 +335,5 @@ app.on("will-quit", () => {
   void builder.dispose();
   void automationBuilder.dispose();
   microphones.dispose();
+  void sensitiveModels.dispose();
 });

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -24,6 +24,11 @@ const IPC = {
   narrationDownload: "narration:download",
   narrationTranscribe: "narration:transcribe",
   narrationStatusChanged: "narration:status-changed",
+  sensitiveModelStatus: "sensitive:status",
+  sensitiveSetAdvanced: "sensitive:set-advanced",
+  sensitiveDownloadModels: "sensitive:download-models",
+  sensitiveStatusChanged: "sensitive:status-changed",
+  sensitiveGetReport: "sensitive:get-report",
   analyze: "analyze:start",
   analyzeFeedback: "analyze:feedback",
   getAnalysis: "analyze:get",
@@ -48,6 +53,7 @@ const IPC = {
   openLibrary: "ui:open-library",
   closeLibrary: "ui:close-library",
   recordingControlsExpanded: "ui:recording-controls-expanded",
+  fitRecorderHeight: "ui:fit-recorder-height",
 };
 
 let recordingPrivacyWarningPending = false;
@@ -103,6 +109,15 @@ contextBridge.exposeInMainWorld("skillRecorder", {
     ipcRenderer.on(IPC.narrationStatusChanged, listener);
     return () => ipcRenderer.removeListener(IPC.narrationStatusChanged, listener);
   },
+  sensitiveModelStatus: () => ipcRenderer.invoke(IPC.sensitiveModelStatus),
+  setAdvancedProtection: (enabled) => ipcRenderer.invoke(IPC.sensitiveSetAdvanced, enabled),
+  downloadSensitiveModels: () => ipcRenderer.invoke(IPC.sensitiveDownloadModels),
+  onSensitiveModelStatusChanged: (cb) => {
+    const listener = (_event, status) => cb(status);
+    ipcRenderer.on(IPC.sensitiveStatusChanged, listener);
+    return () => ipcRenderer.removeListener(IPC.sensitiveStatusChanged, listener);
+  },
+  getSensitiveReport: (sessionId) => ipcRenderer.invoke(IPC.sensitiveGetReport, sessionId),
   analyze: (sessionId) => ipcRenderer.invoke(IPC.analyze, sessionId),
   analyzeFeedback: (input) => ipcRenderer.invoke(IPC.analyzeFeedback, input),
   getAnalysis: (sessionId) => ipcRenderer.invoke(IPC.getAnalysis, sessionId),
@@ -140,4 +155,5 @@ contextBridge.exposeInMainWorld("skillRecorder", {
   closeLibrary: () => ipcRenderer.invoke(IPC.closeLibrary),
   setRecordingControlsExpanded: (expanded) =>
     ipcRenderer.invoke(IPC.recordingControlsExpanded, expanded),
+  fitRecorderHeight: (height) => ipcRenderer.send(IPC.fitRecorderHeight, height),
 });

--- a/electron/sensitive/frame-heuristics.test.ts
+++ b/electron/sensitive/frame-heuristics.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  frameSecretMatches,
+  looksLikeHighEntropySecret,
+  shannonEntropy,
+} from "./frame-heuristics";
+
+/** True when some emitted match's value contains `needle` (ignoring whitespace). */
+function caught(text: string, needle: string): boolean {
+  const strip = (s: string) => s.replace(/\s+/g, "");
+  return frameSecretMatches(text).some((m) => strip(m.value).includes(strip(needle)));
+}
+
+test("catches a GitHub token even when OCR garbled the tail", () => {
+  // The exact glyphs are wrong (OCR), but the long high-entropy run is
+  // unmistakable — caught by shape alone, no `ghp_` prefix rule needed.
+  const ocr = "export GITHUB TOKEN=ghp_la2B3c4D5e6F7g8H910U1k2L3m4N506P7qg8R";
+  assert.ok(caught(ocr, "ghp_la2B3c4D5e6F7g8H910U1k2L3m4N506P7qg8R"));
+});
+
+test("catches an AWS access key id by shape (length + entropy, no prefix rule)", () => {
+  assert.ok(caught("AWS _ACCESS KEY ID=AKIA5SXYO7WZ3PLMN8RTV", "AKIA5SXYO7WZ3PLMN8RTV"));
+});
+
+test("catches a Stripe key whose token OCR split off with a space", () => {
+  // `sk_live` lost its underscore to a space; there is no prefix rule anyway —
+  // the long high-entropy tail is what gets caught, reading-independently.
+  const ocr = "stripe _secret_key: sk_live 4eC39HgqLyjWDarjtTizdp7dcABCDEFGH1234";
+  assert.ok(caught(ocr, "4eC39HgqLyjWDarjtTizdp7dcABCDEFGH1234"));
+});
+
+test("catches a JWT by shape (one long high-entropy token)", () => {
+  const jwt = "eyJhbGci0iJIUzIINilsInRScCI61lkpxvCcJ9.eyJzdWlidilxMjJMONSIsIm5S.dozjgNryP4J3jVmNHLOWSNXgl";
+  assert.ok(caught(`session jwt: ${jwt}`, "eyJhbGci0iJIUzIINilsInRScCI61lkpxvCcJ9"));
+});
+
+test("catches a credential assignment with a short-but-secret value", () => {
+  // Too short / low-entropy for the token rule, but the `password:` context makes
+  // it a clear secret.
+  assert.ok(caught("db password: hunter2Summer", "hunter2Summer"));
+  assert.ok(caught("AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMIbPxRfiCYEXAMPLE", "wJalrXUtnFEMIbPxRfiCYEXAMPLE"));
+});
+
+test("does not flag ordinary prose", () => {
+  assert.deepEqual(frameSecretMatches("the quick brown fox jumps over the lazy dog today"), []);
+});
+
+test("does not flag a URL or a file path", () => {
+  assert.deepEqual(frameSecretMatches("see https://example.com/docs/getting-started/setup"), []);
+  assert.deepEqual(frameSecretMatches("open src/components/Recorder/index.tsx now"), []);
+});
+
+test("does not flag a bare card/phone/digit run (owned by the PII detectors)", () => {
+  assert.deepEqual(frameSecretMatches("4111 1111 1111 1111 and 4155550132"), []);
+});
+
+test("does not flag a git SHA or hex hash (common non-secret)", () => {
+  assert.deepEqual(frameSecretMatches("commit 9f2c1ab4de5607891234abcd5678ef9012345678"), []);
+  assert.equal(looksLikeHighEntropySecret("deadbeefcafebabe0123456789abcdef01234567"), false);
+});
+
+test("high-entropy check requires length, mixed classes, and entropy", () => {
+  assert.equal(looksLikeHighEntropySecret("short1A"), false); // too short
+  assert.equal(looksLikeHighEntropySecret("aaaaaaaaaaaaaaaaaaaaaaaa"), false); // low entropy, one class
+  assert.equal(looksLikeHighEntropySecret("A1b2C3d4E5f6G7h8I9j0K1l2"), true); // long, 3 classes, diverse
+});
+
+test("shannonEntropy grows with character diversity", () => {
+  assert.ok(shannonEntropy("aaaaaaaa") < shannonEntropy("abcdefgh"));
+  assert.equal(shannonEntropy(""), 0);
+});

--- a/electron/sensitive/frame-heuristics.ts
+++ b/electron/sensitive/frame-heuristics.ts
@@ -1,0 +1,164 @@
+// Reading-independent structural detection for the frame (screen-image) path.
+//
+// WHY THIS EXISTS. Frame redaction blurs on-screen secrets by first OCR'ing the
+// image and running our detectors over the recognized text. But OCR is an
+// unreliable reader of HIGH-ENTROPY secrets (API keys, tokens, JWTs): every
+// character is independent, so there's no linguistic context to disambiguate
+// `0/O`, `1/l/I`, `5/S`, `q/g`. We measured this three ways on captured frames —
+// Tesseract (any upscale/threshold/PSM), and even a local vision model
+// (Florence-2) — and ALL of them misread the exact glyphs. A better reader is the
+// wrong axis: transcribing a 40-char random secret from a screenshot is
+// unreliable for any reader (a human included).
+//
+// What DOES survive every reader is the STRUCTURE: a secret is a long, dense,
+// high-entropy run of characters, often introduced by a credential-ish label
+// (`TOKEN=`, `password:`). Those properties are reading-independent — they hold
+// whether or not OCR transcribed the exact glyphs — so we locate a secret by its
+// shape, not by reading it. That is what this module does.
+//
+// Deliberately GENERAL, not a vendor list. We do NOT enumerate issuer prefixes
+// (`ghp_`, `AKIA`, `sk_live_`, …): that is an unbounded, ever-churning blocklist
+// that does not scale, and it is already covered two better ways — secretlint's
+// community-maintained ruleset matches named patterns on clean OCR, and the
+// entropy rule below catches the SAME tokens by shape when OCR garbles them. What
+// remains here are two content-agnostic principles (Shannon entropy over long
+// tokens — the truffleHog technique — and credential-assignment context), so
+// there is nothing per-vendor to maintain.
+//
+// It is deliberately RECALL-first (higher recall, lower precision) and is used
+// ONLY on the frame path — never on the text-redaction path, where over-masking
+// would corrupt the text the model legitimately needs. On a screenshot an
+// occasional extra black box (over a commit SHA or a UUID) is cheap and the user
+// reviews the result; a leaked secret is not. The realistic eval measures the
+// over-blur this trades for.
+
+import type { SensitiveMatch } from "../../common/sensitive";
+
+/** Minimum length for a bare token to be considered a high-entropy secret. Real
+ *  keys/tokens are long; this keeps ordinary identifiers and words out. */
+const MIN_TOKEN_LEN = 20;
+/** Minimum Shannon entropy (bits/char) for a high-entropy token. Random secrets
+ *  sit well above this; repeated or low-diversity strings fall below it. */
+const MIN_ENTROPY = 3.2;
+/** A token must be at least this fraction alphanumeric to qualify (excludes
+ *  punctuation-heavy OCR noise like `(0.0)h(2)h`). */
+const MIN_ALNUM_RATIO = 0.75;
+
+/** Secret-bearing assignments: a credential-ish key followed by `=`/`:` and a
+ *  value. Catches things the entropy rule alone would miss (short-but-secret
+ *  values like a password), and reinforces the token rules. The captured value
+ *  (group 1) is what gets blurred. `key`/`id` alone are intentionally excluded —
+ *  too generic — in favor of explicit secret words. */
+const ASSIGNMENT_RE =
+  /(?:api[_\s-]?key|access[_\s-]?key|secret[_\s-]?key|client[_\s-]?secret|secret|token|password|passwd|pwd|bearer|private[_\s-]?key|credentials?|auth[_\s-]?token)\b["'`]?\s*[:=]\s*["'`]?([^\s"'`]{6,})/gi;
+
+/** Tokens that look like a secret by shape but are common, non-sensitive
+ *  identifiers we should not blur (keeps over-blur down). Pure-hex strings are
+ *  git SHAs / checksums / hashes, not mixed-charset credentials. */
+function isCommonNonSecret(token: string): boolean {
+  return /^(?:0x)?[0-9a-f]+$/i.test(token);
+}
+
+/** Shannon entropy in bits per character. */
+export function shannonEntropy(s: string): number {
+  if (!s) return 0;
+  const freq = new Map<string, number>();
+  for (const ch of s) freq.set(ch, (freq.get(ch) ?? 0) + 1);
+  let h = 0;
+  for (const count of freq.values()) {
+    const p = count / s.length;
+    h -= p * Math.log2(p);
+  }
+  return h;
+}
+
+/** How many of {lowercase, uppercase, digit} a string contains. */
+function alnumClasses(s: string): number {
+  let n = 0;
+  if (/[a-z]/.test(s)) n += 1;
+  if (/[A-Z]/.test(s)) n += 1;
+  if (/[0-9]/.test(s)) n += 1;
+  return n;
+}
+
+/** Fraction of characters that are ASCII alphanumeric. */
+function alnumRatio(s: string): number {
+  const alnum = s.replace(/[^A-Za-z0-9]/g, "").length;
+  return s.length === 0 ? 0 : alnum / s.length;
+}
+
+/** True when a bare token has the shape of a high-entropy secret. Reading-
+ *  independent: it never needs the token to be a valid, checksummed, exact
+ *  pattern — just long, diverse, and dense enough to be a random credential. */
+export function looksLikeHighEntropySecret(token: string): boolean {
+  if (token.length < MIN_TOKEN_LEN) return false;
+  if (token.includes("://")) return false; // a URL, not a bare secret
+  if (isCommonNonSecret(token)) return false; // hex hash / SHA / id
+  if (alnumRatio(token) < MIN_ALNUM_RATIO) return false;
+  // Require BOTH a digit and a letter. Random credentials essentially always mix
+  // them; this cleanly excludes file paths, dotted identifiers, and prose (letters
+  // but no digit) as well as pure digit runs — cards/SSNs/phones, which the
+  // checksum PII detectors own.
+  if (!/[0-9]/.test(token) || !/[A-Za-z]/.test(token)) return false;
+  if (alnumClasses(token) < 2) return false;
+  return shannonEntropy(token) >= MIN_ENTROPY;
+}
+
+function push(
+  out: SensitiveMatch[],
+  value: string,
+  start: number,
+  rank: number,
+): void {
+  if (!value) return;
+  out.push({
+    category: "api-key",
+    label: "Secret-shaped value",
+    severity: "high",
+    value,
+    start,
+    end: start + value.length,
+    rank,
+  });
+}
+
+/**
+ * Locate secret-shaped regions in a frame's OCR text WITHOUT relying on reading
+ * the secret correctly, and WITHOUT a per-vendor prefix list. Emits a
+ * {@link SensitiveMatch} for every:
+ *   - bare token whose length + character-class entropy make it a random
+ *     credential ({@link looksLikeHighEntropySecret}) — this also catches known
+ *     issuer tokens (`ghp_…`, `AKIA…`, `eyJ…`) by shape when OCR garbles them;
+ *   - value assigned to a credential-ish key (`token=…`, `password: …`).
+ *
+ * Named-vendor patterns on clean OCR are handled upstream by secretlint, so there
+ * is no issuer enumeration to maintain here. Frame-only and recall-first by
+ * design; see the file header for the rationale and the precision trade-off.
+ * Offsets are into `text` so the caller can map each match back to the OCR word
+ * boxes that overlap it.
+ */
+export function frameSecretMatches(text: string): SensitiveMatch[] {
+  if (!text) return [];
+  const out: SensitiveMatch[] = [];
+
+  // 1) Assignment right-hand sides (catches short-but-secret values too).
+  ASSIGNMENT_RE.lastIndex = 0;
+  for (let m = ASSIGNMENT_RE.exec(text); m; m = ASSIGNMENT_RE.exec(text)) {
+    const value = m[1];
+    if (value) push(out, value, m.index + m[0].length - value.length, 60);
+    if (m.index === ASSIGNMENT_RE.lastIndex) ASSIGNMENT_RE.lastIndex += 1;
+  }
+
+  // 2) Bare high-entropy tokens (the reading-independent workhorse).
+  const TOKEN_RE = /\S+/g;
+  for (let m = TOKEN_RE.exec(text); m; m = TOKEN_RE.exec(text)) {
+    const raw = m[0];
+    // Trim surrounding punctuation but keep the interior intact, tracking the
+    // offset shift so the emitted span still lines up with `text`.
+    const lead = raw.length - raw.replace(/^[^A-Za-z0-9]+/, "").length;
+    const core = raw.replace(/^[^A-Za-z0-9]+/, "").replace(/[^A-Za-z0-9]+$/, "");
+    if (looksLikeHighEntropySecret(core)) push(out, core, m.index + lead, 50);
+  }
+
+  return out;
+}

--- a/electron/sensitive/frame-redact.test.ts
+++ b/electron/sensitive/frame-redact.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { Ocr, OcrWord } from "./ocr";
+import { OcrFrameRedactor, sensitiveFrameBoxes } from "./frame-redact";
+
+/** Minimal Ocr-shaped stub whose recognize behaviour we control (no tesseract). */
+function stubOcr(recognize: (image: string | Buffer) => Promise<OcrWord[]>): Ocr {
+  return { recognize } as unknown as Ocr;
+}
+
+const word = (text: string, x0: number): OcrWord => ({
+  text,
+  confidence: 90,
+  bbox: { x0, y0: 10, x1: x0 + 80, y1: 40 },
+});
+
+test("frame is withheld (null) when OCR recognition throws", async () => {
+  // Regression guard: a runtime OCR failure must NOT be treated as "blank screen"
+  // (which would serve the frame unblurred). recognize throws → redactFrame → null.
+  const redactor = new OcrFrameRedactor({
+    ocr: stubOcr(async () => {
+      throw new Error("worker crashed");
+    }),
+    knownValues: [],
+  });
+  assert.equal(await redactor.redactFrame("/frames/whatever.jpg"), null);
+  // Cached result is also the safe null (no second recognition attempt).
+  assert.equal(await redactor.redactFrame("/frames/whatever.jpg"), null);
+});
+
+test("sensitiveFrameBoxes flags only the OCR words overlapping a secret", async () => {
+  const words = [
+    word("build", 0),
+    word("token", 90),
+    word("ghp_abcdefghij0123456789ABCDEFGHIJKLMNPQ", 180),
+    word("done", 400),
+  ];
+  const boxes = await sensitiveFrameBoxes(words, { width: 600, height: 60 });
+  assert.equal(boxes.length, 1);
+  // The box covers the token word's region (x0=180), not the clean words.
+  assert.ok(boxes[0].left <= 180 && boxes[0].left + boxes[0].width >= 200);
+});
+
+test("sensitiveFrameBoxes returns nothing for a clean frame", async () => {
+  const words = [word("Public", 0), word("roadmap", 90), word("notes", 180)];
+  assert.deepEqual(await sensitiveFrameBoxes(words, { width: 400, height: 60 }), []);
+});

--- a/electron/sensitive/frame-redact.ts
+++ b/electron/sensitive/frame-redact.ts
@@ -1,0 +1,286 @@
+// Frame OCR + blur for the Advanced protection layer. When Advanced
+// protection is on, screen frames the describer would send to GitHub Copilot are
+// first OCR'd on-device; any word whose text trips the same detectors used for the
+// session's text (secrets, structured PII) — or matches a value already detected
+// elsewhere in the session — is covered with an opaque box before the JPEG leaves
+// the machine. The OCR text itself is never sent; only the blurred image is. Boxes
+// are solid and irreversible (safer than a reversible blur).
+
+import { createRequire } from "node:module";
+
+import {
+  resolveOverlaps,
+  scanStructuredPii,
+  type SensitiveMatch,
+} from "../../common/sensitive";
+import { createLogger } from "../logger";
+import { frameSecretMatches } from "./frame-heuristics";
+import type { Ocr, OcrWord } from "./ocr";
+import { scanSecrets } from "./secrets";
+
+const require = createRequire(import.meta.url);
+const log = createLogger("Sensitive/frames");
+
+type Sharp = typeof import("sharp");
+let sharpMod: Sharp | null | undefined;
+function sharp(): Sharp | null {
+  if (sharpMod === undefined) {
+    try {
+      sharpMod = require("sharp") as Sharp;
+    } catch (err) {
+      log.warn("sharp unavailable; frame blur disabled:", message(err));
+      sharpMod = null;
+    }
+  }
+  return sharpMod;
+}
+
+function message(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+interface Rect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+/** A pixel box to paint over a sensitive region of a frame. */
+export type FrameBox = Rect;
+
+export interface FrameBoxOptions {
+  width: number;
+  height: number;
+  /** Values already detected in the session's text (cross-feed blur). */
+  knownValues?: string[];
+  /** Padding added around each detected word box, in pixels. */
+  padding?: number;
+}
+
+/**
+ * Map every sensitive region in a set of OCR words to a padded pixel box. Runs the
+ * shared detectors (secrets + structured PII) over the recognized text, plus a
+ * literal search for known session values, then selects every OCR word whose
+ * character span overlaps a match. Pure and side-effect-free (no sharp, no image
+ * IO) so it can be exercised deterministically. Returns the boxes to blur.
+ */
+export async function sensitiveFrameBoxes(words: OcrWord[], opts: FrameBoxOptions): Promise<FrameBox[]> {
+  if (words.length === 0) return [];
+  const padding = opts.padding ?? 4;
+  const knownValues = [...new Set((opts.knownValues ?? []).filter((v) => v.length >= 3))];
+
+  // Join words into one string, remembering each word's char span + box. Tesseract
+  // often emits an "@" (or a value split around one) as its own token with spaces on
+  // each side, e.g. `jordan.blake @ example.com`; a space next to "@" is never
+  // meaningful in the values we detect, so we glue across it to keep emails intact
+  // for the detectors. Other separators (spaces in card/phone numbers) are preserved.
+  let joined = "";
+  const spans: Array<{ start: number; end: number; word: OcrWord }> = [];
+  for (const word of words) {
+    const glue = joined.endsWith("@") || word.text.startsWith("@");
+    if (joined && !glue) joined += " ";
+    const start = joined.length;
+    joined += word.text;
+    spans.push({ start, end: joined.length, word });
+  }
+
+  const matches = await matchesInOcrText(joined, knownValues);
+  if (matches.length === 0) return [];
+
+  const rects: FrameBox[] = [];
+  const seen = new Set<OcrWord>();
+  for (const match of matches) {
+    for (const span of spans) {
+      if (span.start < match.end && match.start < span.end && !seen.has(span.word)) {
+        seen.add(span.word);
+        rects.push(boxFor(span.word, opts.width, opts.height, padding));
+      }
+    }
+  }
+  return rects;
+}
+
+/** All detector matches in the recognized text, plus literal known-value hits. */
+async function matchesInOcrText(
+  text: string,
+  knownValues: string[],
+): Promise<SensitiveMatch[]> {
+  const secrets = await scanSecrets(text);
+  const pii = scanStructuredPii(text);
+  // Frame-only, reading-independent structural detection: locates secret-shaped
+  // regions (high-entropy tokens, credential assignments) even when OCR garbles
+  // the exact glyphs, which the fixed-pattern secret detectors above require.
+  // Recall-first — see frame-heuristics.ts for the trade-off.
+  const structural = frameSecretMatches(text);
+  const known: SensitiveMatch[] = [];
+  for (const value of knownValues) {
+    for (let i = text.indexOf(value); i >= 0; i = text.indexOf(value, i + 1)) {
+      known.push({
+        category: "password",
+        label: "Known sensitive value",
+        severity: "high",
+        value,
+        start: i,
+        end: i + value.length,
+        rank: 100,
+      });
+    }
+  }
+  return resolveOverlaps([...secrets, ...pii, ...structural, ...known]);
+}
+
+/** A padded, image-clamped box for one OCR word. */
+function boxFor(word: OcrWord, width: number, height: number, padding: number): Rect {
+  const x0 = Math.max(0, Math.floor(word.bbox.x0) - padding);
+  const y0 = Math.max(0, Math.floor(word.bbox.y0) - padding);
+  const x1 = Math.min(width, Math.ceil(word.bbox.x1) + padding);
+  const y1 = Math.min(height, Math.ceil(word.bbox.y1) + padding);
+  return { left: x0, top: y0, width: Math.max(1, x1 - x0), height: Math.max(1, y1 - y0) };
+}
+
+/**
+ * Redacts sensitive regions from screen frames before they're sent. The get_frames
+ * tool uses the flags to decide policy:
+ *   - `active` false → Advanced protection is off; serve raw frames (baseline).
+ *   - `active` true, `ready` false → assets still loading; WITHHOLD frames.
+ *   - `active` true, `ready` true → blur detected regions per frame.
+ */
+export interface FrameRedactor {
+  /** Advanced protection is on for this run (frames must be protected). */
+  readonly active: boolean;
+  /** OCR is available; when false while `active`, the caller withholds frames. */
+  readonly ready: boolean;
+  /** Running tally of what was blurred across this analyze run, for the review
+   *  summary. Counts each source frame once (repeat requests are cached). */
+  readonly stats: FrameRedactionStats;
+  /** Produce a protected JPEG for a source frame, or null on failure (the caller
+   *  then withholds that frame rather than risk serving raw pixels). */
+  redactFrame(sourceFramePath: string): Promise<Buffer | null>;
+}
+
+/** How many screen images were blurred, and how many on-screen regions in them. */
+export interface FrameRedactionStats {
+  /** Distinct source frames in which at least one region was covered. */
+  framesBlurred: number;
+  /** Total regions (boxes) painted across all frames. */
+  regionsBlurred: number;
+}
+
+const NO_FRAME_STATS: FrameRedactionStats = Object.freeze({ framesBlurred: 0, regionsBlurred: 0 });
+
+/** A no-op redactor for when Advanced protection is off — frames pass through. */
+export const INACTIVE_FRAME_REDACTOR: FrameRedactor = {
+  active: false,
+  ready: true,
+  stats: NO_FRAME_STATS,
+  redactFrame: async () => null,
+};
+
+/** A fail-safe redactor for when Advanced protection is ON but the scan could not
+ *  run (e.g. it threw): `active` with `ready:false` makes get_frames WITHHOLD every
+ *  frame rather than serve raw pixels we never got a chance to inspect. */
+export const WITHHOLD_FRAME_REDACTOR: FrameRedactor = {
+  active: true,
+  ready: false,
+  stats: NO_FRAME_STATS,
+  redactFrame: async () => null,
+};
+
+export interface FrameRedactorOptions {
+  ocr: Ocr | null;
+  /** Values already detected in the session's text (cross-feed blur). */
+  knownValues: string[];
+  /** Padding added around each detected word box, in pixels. */
+  padding?: number;
+}
+
+/**
+ * OCR-backed frame redactor. Recognizes words + boxes, runs the shared detectors
+ * over the recognized text (plus a literal search for known session values), and
+ * paints an opaque box over every matched word. Results are cached per source
+ * frame path for the lifetime of the redactor (one analyze run).
+ */
+export class OcrFrameRedactor implements FrameRedactor {
+  readonly active = true;
+  private readonly ocr: Ocr | null;
+  private readonly knownValues: string[];
+  private readonly padding: number;
+  private readonly cache = new Map<string, Buffer | null>();
+  private framesBlurred = 0;
+  private regionsBlurred = 0;
+
+  constructor(opts: FrameRedactorOptions) {
+    this.ocr = opts.ocr;
+    this.knownValues = [...new Set(opts.knownValues.filter((v) => v.length >= 3))];
+    this.padding = opts.padding ?? 4;
+  }
+
+  get ready(): boolean {
+    return this.ocr != null && sharp() != null;
+  }
+
+  get stats(): FrameRedactionStats {
+    return { framesBlurred: this.framesBlurred, regionsBlurred: this.regionsBlurred };
+  }
+
+  async redactFrame(sourceFramePath: string): Promise<Buffer | null> {
+    if (!this.ocr) return null;
+    const cached = this.cache.get(sourceFramePath);
+    if (cached !== undefined) return cached;
+    let result: Buffer | null;
+    try {
+      result = await this.buildRedactedFrame(sourceFramePath);
+    } catch (err) {
+      log.warn("frame redaction failed:", message(err));
+      result = null;
+    }
+    this.cache.set(sourceFramePath, result);
+    return result;
+  }
+
+  private async buildRedactedFrame(sourceFramePath: string): Promise<Buffer | null> {
+    const s = sharp();
+    if (!s || !this.ocr) return null;
+
+    // Throws on OCR engine failure → caught by redactFrame → the frame is withheld
+    // (never served unblurred). A text-free frame resolves to [] and serves normally.
+    const words = await this.ocr.recognize(sourceFramePath);
+    const image = s(sourceFramePath);
+    const meta = await image.metadata();
+    const width = meta.width ?? 0;
+    const height = meta.height ?? 0;
+    if (!width || !height) return null;
+
+    const boxes = await sensitiveFrameBoxes(words, {
+      width,
+      height,
+      knownValues: this.knownValues,
+      padding: this.padding,
+    });
+    if (boxes.length === 0) {
+      // Nothing sensitive on screen — re-encode so callers uniformly serve the
+      // redactor's output (and never accidentally serve the raw file bytes).
+      return image.jpeg({ quality: 85 }).toBuffer();
+    }
+
+    // Count once per distinct source frame (redactFrame caches, so buildRedactedFrame
+    // only runs on the first request for a given path).
+    this.framesBlurred += 1;
+    this.regionsBlurred += boxes.length;
+
+    const overlays = boxes.map((box) => ({
+      input: {
+        create: {
+          width: box.width,
+          height: box.height,
+          channels: 3 as const,
+          background: { r: 17, g: 17, b: 17 },
+        },
+      },
+      left: box.left,
+      top: box.top,
+    }));
+    return image.composite(overlays).jpeg({ quality: 85 }).toBuffer();
+  }
+}

--- a/electron/sensitive/model-manager.ts
+++ b/electron/sensitive/model-manager.ts
@@ -1,0 +1,392 @@
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, rename, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import type {
+  SensitiveModelActionResult,
+  SensitiveModelStatus,
+} from "../../common/ipc";
+import { createLogger } from "../logger";
+import { modelsCacheDir, Ocr, tessdataFileName } from "./ocr";
+import { tessdataUrl, verifyTessdata } from "./tessdata-source";
+
+const log = createLogger("Sensitive/models");
+
+/** Advanced protection reads on-screen text with English (Latin) OCR. Every value
+ *  it looks for — keys, tokens, emails, cards, IDs — is ASCII by construction, so
+ *  English OCR reads them on any-language UI; there is nothing to select. */
+const OCR_LANGUAGE = "eng";
+
+/** How long Analyze waits for Advanced-protection OCR to finish provisioning before
+ *  falling back to withholding frames. Generous enough for the small first-run
+ *  download on a slow link, but bounded so an offline/broken fetch can't hang the
+ *  analysis indefinitely. */
+const READY_TIMEOUT_MS = 30_000;
+
+function message(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Await `task`, but resolve after `ms` regardless, so a stuck/slow download can
+ *  never block the caller past the deadline. Never rejects. */
+function settleWithTimeout(task: Promise<unknown>, ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(done, ms);
+    if (typeof timer.unref === "function") timer.unref();
+    void Promise.resolve(task).then(done, done);
+  });
+}
+
+/** Where the persisted opt-in lives — inside the models dir so a single override
+ *  (SKILL_RECORDER_MODELS_DIR) relocates both the flag and the model cache. */
+function settingsFile(): string {
+  return path.join(modelsCacheDir(), "advanced-protection.json");
+}
+
+function tessdataDir(): string {
+  return path.join(modelsCacheDir(), "tessdata");
+}
+
+/** True once the English traineddata is on disk and the OCR engine can be built. */
+function isTessdataCached(): boolean {
+  return existsSync(path.join(tessdataDir(), tessdataFileName(OCR_LANGUAGE)));
+}
+
+interface AdvancedSettings {
+  enabled: boolean;
+}
+
+function readSettings(): AdvancedSettings {
+  try {
+    const raw = JSON.parse(readFileSync(settingsFile(), "utf8")) as { enabled?: unknown };
+    // Opt-out: on unless the user explicitly turned it off.
+    return { enabled: raw.enabled !== false };
+  } catch {
+    // No preference recorded yet → on by default (fresh install).
+    return { enabled: true };
+  }
+}
+
+async function writeSettings(settings: AdvancedSettings): Promise<void> {
+  const file = settingsFile();
+  await mkdir(path.dirname(file), { recursive: true });
+  const tmp = `${file}.tmp.${process.pid}.${Date.now()}`;
+  try {
+    await writeFile(tmp, JSON.stringify(settings, null, 2));
+    await rename(tmp, file);
+  } finally {
+    await rm(tmp, { force: true });
+  }
+}
+
+/** Download the Tesseract language data to the models dir (atomic temp+rename). */
+async function downloadTessdata(
+  code: string,
+  onProgress?: (percent: number) => void,
+): Promise<void> {
+  const dir = tessdataDir();
+  await mkdir(dir, { recursive: true });
+  const dest = path.join(dir, tessdataFileName(code));
+  const tmp = `${dest}.tmp.${process.pid}.${Date.now()}`;
+  const res = await fetch(tessdataUrl(code));
+  if (!res.ok || !res.body)
+    throw new Error(`Could not download OCR language data for "${code}" (${res.status}).`);
+  const total = Number(res.headers.get("content-length")) || 0;
+  let loaded = 0;
+  const chunks: Buffer[] = [];
+  for await (const chunk of res.body as unknown as AsyncIterable<Uint8Array>) {
+    const buf = Buffer.from(chunk);
+    chunks.push(buf);
+    loaded += buf.length;
+    if (total) onProgress?.(Math.floor((loaded / total) * 100));
+  }
+  try {
+    const data = Buffer.concat(chunks);
+    // Reject tampered/corrupt data BEFORE it lands in the cache or reaches the WASM
+    // parser: the temp file is discarded and `dest` is never written on mismatch.
+    verifyTessdata(code, data);
+    await writeFile(tmp, data);
+    await rename(tmp, dest);
+  } finally {
+    await rm(tmp, { force: true });
+  }
+}
+
+/**
+ * Owns the on-device Tesseract English OCR data used to blur sensitive text in screen
+ * images, behind a single persisted `enabled` flag. That flag is the ONE opt-out for
+ * all on-device protection: when on (the default) the analyze pipeline both masks
+ * secrets/PII in the outgoing text and blurs them in screen images; when the user turns
+ * it off, neither is applied and the recording is sent unredacted. On first launch, when
+ * enabled but the data is not cached yet, the small (~few MB) model is fetched
+ * automatically in the background so "on by default" actually protects the very first
+ * analysis; Analyze then waits briefly (bounded) for that provisioning to finish rather
+ * than dropping frames, and only withholds them if the model still is not ready in time.
+ * Disabling keeps the cache so re-enabling is instant. Never throws into the Analyze
+ * path: `getOcr` returns null when unavailable.
+ */
+export class SensitiveModelManager {
+  private current: SensitiveModelStatus = {
+    enabled: true,
+    ocr: "missing",
+    progress: null,
+    error: null,
+  };
+  private ocr: Ocr | null = null;
+  private downloadTask: Promise<SensitiveModelActionResult> | null = null;
+  /** Bumped on every enable/disable. A warm that started under an older generation
+   *  refuses to publish, so `this.ocr` (and the "ready" status) can never reflect an
+   *  engine built for a since-disabled layer. */
+  private ocrGen = 0;
+  /** Serializes engine build/warm/terminate so concurrent lifecycle ops never spin up
+   *  overlapping worker pools or race the published engine. */
+  private ocrLifecycle: Promise<unknown> = Promise.resolve();
+  /** Serializes settings writes so a reported success always reflects a completed,
+   *  in-order persist. */
+  private settingsChain: Promise<unknown> = Promise.resolve();
+
+  constructor(private readonly emitStatus: (status: SensitiveModelStatus) => void) {}
+
+  /** Load the persisted opt-out and reflect what's cached. Warms already-downloaded
+   *  data so it's ready without a click; when protection is on but the data isn't
+   *  cached yet (typically first launch), fetches it automatically in the background
+   *  so the default-on layer is actually functional. */
+  initialize(): void {
+    const settings = readSettings();
+    const cached = isTessdataCached();
+    this.current = {
+      enabled: settings.enabled,
+      ocr: cached ? "ready" : "missing",
+      progress: null,
+      error: null,
+    };
+    this.emit();
+    if (!settings.enabled) return;
+    if (cached) {
+      // Warm from cache (no network) so a returning, provisioned user is ready.
+      void this.warmFromCache(this.ocrGen);
+    } else {
+      // On by default but not yet provisioned — fetch the small model in the
+      // background. Deduped through downloadModels(); non-blocking and self-healing.
+      log.info("advanced protection on; provisioning OCR model in background");
+      void this.downloadModels();
+    }
+  }
+
+  status(): SensitiveModelStatus {
+    return { ...this.current };
+  }
+
+  isAdvancedEnabled(): boolean {
+    return this.current.enabled;
+  }
+
+  isAdvancedReady(): boolean {
+    return this.current.enabled && this.current.ocr === "ready";
+  }
+
+  /** Toggle Advanced protection. Enabling persists it and provisions the model —
+   *  warming from cache when present, else fetching it in the background; disabling
+   *  persists it off and releases OCR workers while keeping the cache. */
+  async setAdvanced(enabled: boolean): Promise<SensitiveModelActionResult> {
+    if (!enabled) return this.disable();
+
+    const gen = ++this.ocrGen;
+    const cached = isTessdataCached();
+    this.update({
+      enabled: true,
+      ocr: cached ? "ready" : "missing",
+      error: null,
+    });
+    const persisted = await this.persistSettings({ enabled: true });
+    if (cached) {
+      // Data on disk — warm it so it's usable right away.
+      void this.warmFromCache(gen);
+    } else {
+      // Not provisioned yet — fetch it in the background so turning protection on
+      // actually makes it work, rather than silently withholding frames.
+      void this.downloadModels();
+    }
+    return persisted;
+  }
+
+  /** Download the OCR data (if missing) and warm the engine. The deliberate
+   *  "download" action behind the HUD doctor row; safe to call repeatedly. */
+  downloadModels(): Promise<SensitiveModelActionResult> {
+    if (!this.current.enabled) return Promise.resolve({ ok: false, error: "Advanced protection is off." });
+    if (this.downloadTask) return this.downloadTask;
+    const task = this.provisionOcr();
+    this.downloadTask = task;
+    void task.finally(() => {
+      if (this.downloadTask === task) this.downloadTask = null;
+    });
+    return task;
+  }
+
+  /** The OCR engine when Advanced is enabled and language data is present, else
+   *  null (callers then withhold frames rather than serve raw pixels). */
+  getOcr(): Ocr | null {
+    if (!this.current.enabled || this.current.ocr !== "ready") return null;
+    return this.ocr;
+  }
+
+  /** Await OCR readiness for up to `timeoutMs`, provisioning the model if needed.
+   *  Resolves true when frames can be blurred; false when protection is off, the
+   *  model has errored, or provisioning didn't finish in time — callers then withhold
+   *  frames rather than block forever (e.g. offline). Never throws. This lets Analyze
+   *  briefly wait out a fresh first-run download instead of silently dropping every
+   *  screen frame the moment the model isn't ready. */
+  async ensureReady(timeoutMs = READY_TIMEOUT_MS): Promise<boolean> {
+    if (!this.current.enabled) return false;
+    if (this.current.ocr === "ready") return true;
+    // A persistent error won't clear by waiting — withhold now; the HUD offers Retry.
+    if (this.current.ocr === "error") return false;
+    // "missing"/"downloading": ensure provisioning is running (reusing the launch-time
+    // auto-provision task when present) and await it, bounded by the deadline.
+    const task = this.downloadModels();
+    await settleWithTimeout(task, timeoutMs);
+    return this.isAdvancedReady();
+  }
+
+  /** Tear down OCR workers (app quit). */
+  async dispose(): Promise<void> {
+    const ocr = this.ocr;
+    this.ocr = null;
+    if (ocr) await ocr.terminate();
+  }
+
+  // --- internals -----------------------------------------------------------
+
+  /** Download the English data (if missing) then warm the worker pool so readiness
+   *  is genuine. Skips publishing if the layer was disabled while fetching. */
+  private async provisionOcr(): Promise<SensitiveModelActionResult> {
+    const gen = this.ocrGen;
+    this.update({ error: null });
+    try {
+      if (!isTessdataCached()) {
+        this.update({ ocr: "downloading", progress: 0 });
+        await downloadTessdata(OCR_LANGUAGE, (p) => this.onDownloadProgress(p));
+      }
+      await this.buildAndWarmOcr(gen);
+      if (gen === this.ocrGen) this.update({ ocr: "ready", progress: null });
+      return { ok: true };
+    } catch (err) {
+      if (gen === this.ocrGen) this.update({ ocr: "error", progress: null, error: message(err) });
+      return { ok: false, error: message(err) };
+    }
+  }
+
+  /** Rebuild the OCR pool from already-cached data (no network). */
+  private async warmFromCache(gen: number): Promise<SensitiveModelActionResult> {
+    try {
+      await this.buildAndWarmOcr(gen);
+      if (gen === this.ocrGen) this.update({ ocr: "ready", error: null });
+      return { ok: true };
+    } catch (err) {
+      if (gen === this.ocrGen) this.update({ ocr: "error", error: message(err) });
+      return { ok: false, error: message(err) };
+    }
+  }
+
+  /**
+   * Build + warm an OCR pool and publish it only if the layer is still enabled and
+   * the generation is unchanged. A failed warm or a since-disabled layer terminates
+   * the fresh engine, so no unready engine is ever handed to `getOcr()`. Serialized
+   * so overlapping lifecycle ops can't spin up competing pools.
+   */
+  private buildAndWarmOcr(gen: number): Promise<void> {
+    return this.runOcrLifecycle(async () => {
+      if (gen !== this.ocrGen || !this.current.enabled) return;
+      const next = new Ocr({ langPath: tessdataDir() });
+      try {
+        await next.warm();
+      } catch (err) {
+        await next.terminate();
+        throw err;
+      }
+      if (gen !== this.ocrGen || !this.current.enabled) {
+        // Enabled state changed while warming — discard this engine.
+        await next.terminate();
+        return;
+      }
+      const old = this.ocr;
+      this.ocr = next;
+      if (old) await old.terminate();
+    });
+  }
+
+  /** Terminate and drop the current OCR pool (serialized with builds). */
+  private releaseOcr(): Promise<void> {
+    return this.runOcrLifecycle(async () => {
+      const ocr = this.ocr;
+      this.ocr = null;
+      if (ocr) await ocr.terminate();
+    });
+  }
+
+  /** Run an OCR lifecycle op after any in-flight one, regardless of its outcome. */
+  private runOcrLifecycle<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.ocrLifecycle.then(fn, fn);
+    this.ocrLifecycle = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  /** Persist settings in submission order and await completion so success is never
+   *  reported before the write lands. Returns a failure result instead of throwing. */
+  private persistSettings(settings: AdvancedSettings): Promise<SensitiveModelActionResult> {
+    const run = this.settingsChain.then(() => writeSettings(settings));
+    this.settingsChain = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run.then(
+      () => ({ ok: true }) as SensitiveModelActionResult,
+      (err) => {
+        log.warn("could not persist advanced-protection settings:", message(err));
+        return { ok: false, error: message(err) } as SensitiveModelActionResult;
+      },
+    );
+  }
+
+  private async disable(): Promise<SensitiveModelActionResult> {
+    // Supersede any in-flight warm so it can't publish an engine after we've disabled.
+    this.update({ enabled: false });
+    ++this.ocrGen;
+    const persisted = await this.persistSettings({ enabled: false });
+    await this.releaseOcr();
+    // Keep the cache on disk; just reflect that the layer won't be applied. State
+    // falls back to whether the file is present so re-enabling is instant.
+    this.update({
+      enabled: false,
+      ocr: isTessdataCached() ? "ready" : "missing",
+      progress: null,
+      error: null,
+    });
+    return persisted;
+  }
+
+  private onDownloadProgress(percent: number): void {
+    const clamped = Math.max(0, Math.min(100, Math.floor(percent)));
+    if (clamped === this.current.progress) return;
+    this.update({ ocr: "downloading", progress: clamped });
+  }
+
+  private update(patch: Partial<SensitiveModelStatus>): void {
+    this.current = { ...this.current, ...patch };
+    this.emit();
+  }
+
+  private emit(): void {
+    this.emitStatus(this.status());
+  }
+}

--- a/electron/sensitive/ocr.test.ts
+++ b/electron/sensitive/ocr.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { Ocr } from "./ocr";
+
+// The pool works with tesseract's Worker type; fakes are cast to it. Type-only import,
+// so tesseract.js is never actually loaded when these tests run.
+type Tesseract = typeof import("tesseract.js");
+type TWorker = Awaited<ReturnType<Tesseract["createWorker"]>>;
+
+interface TermLog {
+  terminated: number;
+}
+
+function fakeWorker(log: TermLog, recognizeImpl?: () => Promise<unknown>): TWorker {
+  return {
+    terminate: async () => {
+      log.terminated += 1;
+    },
+    recognize: recognizeImpl ?? (async () => ({ data: { blocks: [] } })),
+    setParameters: async () => undefined,
+  } as unknown as TWorker;
+}
+
+const settle = (ms = 20): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+test("ensureInit rolls back partially-built workers when one fails to spawn", async () => {
+  const log: TermLog = { terminated: 0 };
+  let spawns = 0;
+
+  class PartialOcr extends Ocr {
+    override isLanguageDataPresent(): boolean {
+      return true;
+    }
+    protected override async spawnWorker(): Promise<TWorker> {
+      spawns += 1;
+      if (spawns === 2) throw new Error("spawn boom");
+      return fakeWorker(log);
+    }
+  }
+
+  const ocr = new PartialOcr({ langPath: "/unused", poolSize: 2 });
+  await assert.rejects(ocr.warm(), /spawn boom/);
+  // The worker built before the failure must be torn down, not left leaked in the pool.
+  assert.equal(log.terminated, 1);
+  assert.equal(spawns, 2);
+});
+
+test("ensureInit retries cleanly after a failed warm (no duplicated pool)", async () => {
+  const log: TermLog = { terminated: 0 };
+  let spawns = 0;
+  let failNext = true;
+
+  class RetryOcr extends Ocr {
+    override isLanguageDataPresent(): boolean {
+      return true;
+    }
+    protected override async spawnWorker(): Promise<TWorker> {
+      spawns += 1;
+      if (failNext && spawns === 2) throw new Error("spawn boom");
+      return fakeWorker(log);
+    }
+  }
+
+  const ocr = new RetryOcr({ langPath: "/unused", poolSize: 2 });
+  await assert.rejects(ocr.warm(), /spawn boom/); // 1 built + rolled back, then boom
+  assert.equal(log.terminated, 1);
+
+  failNext = false;
+  await ocr.warm(); // builds a fresh pool of exactly 2
+  await ocr.terminate();
+  // 1 rolled-back worker + exactly 2 in the live pool. A duplicated pool would be higher.
+  assert.equal(log.terminated, 3);
+});
+
+test("terminate() rejects a queued recognition instead of hanging", async () => {
+  const log: TermLog = { terminated: 0 };
+  let openGate: () => void = () => undefined;
+  const gate = new Promise<void>((resolve) => {
+    openGate = resolve;
+  });
+
+  class GatedOcr extends Ocr {
+    override isLanguageDataPresent(): boolean {
+      return true;
+    }
+    protected override async spawnWorker(): Promise<TWorker> {
+      // A single worker whose recognize blocks on the gate, forcing a second
+      // concurrent recognize to queue behind it.
+      return fakeWorker(log, async () => {
+        await gate;
+        return { data: { blocks: [] } };
+      });
+    }
+  }
+
+  const ocr = new GatedOcr({ langPath: "/unused", poolSize: 1 });
+  const img = Buffer.from([1, 2, 3, 4]); // not a real image → preprocessing falls back
+
+  const first = ocr.recognize(img); // acquires the only worker, blocks on the gate
+  await settle();
+  const second = ocr.recognize(img); // no idle worker → queues as a waiter
+  await settle();
+
+  await ocr.terminate(); // must fail the queued recognition rather than leave it pending
+  await assert.rejects(second, /terminated/);
+
+  openGate();
+  await first.catch(() => undefined); // let the in-flight recognition unwind
+});

--- a/electron/sensitive/ocr.ts
+++ b/electron/sensitive/ocr.ts
@@ -1,0 +1,295 @@
+// On-device OCR for the Advanced protection layer. Wraps tesseract.js v7
+// (Apache-2.0) behind a small worker pool. Used only to LOCATE text regions in
+// screen frames so they can be blurred before a JPEG leaves the machine — the OCR
+// text itself is never sent to the model. Fully offline: the WASM core ships in
+// the tesseract.js-core node_module and the language data is a local file the
+// model manager downloads once into the app's models dir.
+
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+import { app } from "electron";
+
+import { createLogger } from "../logger";
+import { tessdataFileName } from "./tessdata-source";
+
+export { tessdataFileName };
+
+const require = createRequire(import.meta.url);
+const log = createLogger("Sensitive/ocr");
+
+type SharpModule = typeof import("sharp");
+let sharpMod: SharpModule | null | undefined;
+function sharp(): SharpModule | null {
+  if (sharpMod === undefined) {
+    try {
+      sharpMod = require("sharp") as SharpModule;
+    } catch (err) {
+      log.warn("sharp unavailable; OCR preprocessing disabled:", err instanceof Error ? err.message : err);
+      sharpMod = null;
+    }
+  }
+  return sharpMod;
+}
+
+// Captured screen frames are heavily downscaled (~1100px wide), which turns small
+// UI / spreadsheet text into OCR garbage — the detectors then match nothing and
+// sensitive regions would ship unblurred. Before recognizing, we upscale, drop to
+// grayscale, and stretch contrast so small text becomes legible to Tesseract. The
+// box coordinates are divided back down by the applied scale so callers still get
+// boxes in the SOURCE image's pixel space. Width is capped so a large display can't
+// blow up OCR cost.
+//
+// 3× was chosen by A/B'ing config candidates through the realistic degraded-frame
+// eval (evals/sensitive/ocr-realistic.ts). Dictionary-disable, user_defined_dpi,
+// PSM 11 and inversion all moved nothing. 4× is NOT a free win: it lets one extra
+// borderline token (a 20-char AWS key) land on-pattern, but at the same time flips a
+// digit in a Visa number so it fails the Luhn check and leaks — trading a common,
+// high-value card for a rare vision-only key that captured terminal/clipboard text
+// usually cross-feeds anyway. So we stay at 3×; high-entropy secrets that appear
+// ONLY on screen are an accepted OCR gap (see the xfail cases in the eval).
+const OCR_UPSCALE = 3;
+const OCR_MAX_WIDTH = 3600;
+
+/** Upscale + grayscale + contrast-normalise an image for OCR. Returns the processed
+ *  buffer and the scale factor applied (so word boxes can be mapped back to source
+ *  pixels). Falls back to the original input at scale 1 if sharp is unavailable or
+ *  preprocessing fails. */
+async function preprocessForOcr(image: string | Buffer): Promise<{ input: string | Buffer; scale: number }> {
+  const s = sharp();
+  if (!s) return { input: image, scale: 1 };
+  try {
+    const pipeline = s(image);
+    const meta = await pipeline.metadata();
+    const width = meta.width ?? 0;
+    if (!width) return { input: image, scale: 1 };
+    const target = Math.min(width * OCR_UPSCALE, OCR_MAX_WIDTH);
+    const scale = target / width;
+    if (scale <= 1) return { input: image, scale: 1 };
+    const buffer = await pipeline.resize({ width: Math.round(target) }).grayscale().normalise().toBuffer();
+    return { input: buffer, scale };
+  } catch (err) {
+    log.warn("OCR preprocessing failed; using raw image:", err instanceof Error ? err.message : err);
+    return { input: image, scale: 1 };
+  }
+}
+
+/** Where downloaded on-device models live — shared with narration so one dir holds
+ *  them all. Overridable via SKILL_RECORDER_MODELS_DIR for tests/CI. */
+export function modelsCacheDir(): string {
+  const override = process.env.SKILL_RECORDER_MODELS_DIR;
+  if (override) return path.resolve(override);
+  return path.join(app.getPath("userData"), "models");
+}
+
+/** LSTM-only engine — matches the fast LSTM traineddata and skips legacy components. */
+const OEM_LSTM_ONLY = 1;
+
+/** One recognized word with its pixel bounding box in the source image. */
+export interface OcrWord {
+  text: string;
+  confidence: number;
+  bbox: { x0: number; y0: number; x1: number; y1: number };
+}
+
+type TesseractModule = typeof import("tesseract.js");
+type TWorker = Awaited<ReturnType<TesseractModule["createWorker"]>>;
+
+interface RawWord {
+  text?: string;
+  confidence?: number;
+  bbox?: { x0: number; y0: number; x1: number; y1: number };
+}
+interface RawPage {
+  blocks?: Array<{ paragraphs?: Array<{ lines?: Array<{ words?: RawWord[] }> }> }> | null;
+}
+
+/** Absolute path to the tesseract.js-core package dir (holds the WASM variants).
+ *  Resolved from node_modules at runtime like the app's other native deps. */
+export function resolveCorePath(): string {
+  return path.dirname(require.resolve("tesseract.js-core/package.json"));
+}
+
+export interface OcrOptions {
+  /** Directory containing the `<code>.traineddata` files (managed by the model manager). */
+  langPath: string;
+  /** Number of reusable workers. Small by default — a few frames per call. */
+  poolSize?: number;
+}
+
+/**
+ * A reusable pool of tesseract workers. Workers are expensive to create (each
+ * loads the WASM core + language data), so they're built once on first use and
+ * reused across recognitions. Recognitions beyond the pool size queue until a
+ * worker frees up. `recognize` THROWS on engine failure (rather than returning an
+ * empty result) so the frame redactor can tell "OCR failed" apart from "blank
+ * screen" and withhold the frame instead of serving unblurred pixels; a genuinely
+ * text-free image still resolves with an empty word list.
+ *
+ * Before recognition each image is upscaled + grayscaled + contrast-normalised
+ * (see `preprocessForOcr`) because captured frames are downscaled enough that small
+ * on-screen text would otherwise OCR to garbage and defeat the blur pass. Word boxes
+ * are mapped back to the source image's pixel space before they're returned.
+ */
+export class Ocr {
+  private readonly langPath: string;
+  private readonly lang: string;
+  private readonly poolSize: number;
+  private tesseract: TesseractModule | null = null;
+  private workers: TWorker[] = [];
+  private idle: TWorker[] = [];
+  private readonly waiters: Array<{
+    resolve: (worker: TWorker) => void;
+    reject: (err: Error) => void;
+  }> = [];
+  private initPromise: Promise<void> | null = null;
+  private terminated = false;
+
+  constructor(opts: OcrOptions) {
+    this.langPath = opts.langPath;
+    this.lang = "eng";
+    this.poolSize = Math.max(1, Math.min(4, opts.poolSize ?? 2));
+  }
+
+  /** True once the English tessdata exists and workers can be built. */
+  isLanguageDataPresent(): boolean {
+    return existsSync(path.join(this.langPath, tessdataFileName(this.lang)));
+  }
+
+  /** Eagerly build the worker pool so the first frame isn't slow and readiness is
+   *  genuine (surfaces a load failure now rather than at serve time). */
+  async warm(): Promise<void> {
+    await this.ensureInit();
+  }
+
+  private async ensureInit(): Promise<void> {
+    if (this.initPromise) return this.initPromise;
+    this.initPromise = (async () => {
+      if (!this.isLanguageDataPresent()) {
+        throw new Error("OCR language data is not available.");
+      }
+      // Build into a local list and only publish the pool once EVERY worker is up, so
+      // a failure partway through doesn't leave half-built workers in the pool for a
+      // retry to duplicate (and leak).
+      const built: TWorker[] = [];
+      try {
+        for (let i = 0; i < this.poolSize; i++) built.push(await this.spawnWorker());
+      } catch (err) {
+        await Promise.all(built.map((w) => w.terminate().catch(() => undefined)));
+        throw err;
+      }
+      if (this.terminated) {
+        // terminate() ran while we were building: tear the new set down instead of
+        // publishing it, so disabling protection mid-warm can't leave live workers.
+        await Promise.all(built.map((w) => w.terminate().catch(() => undefined)));
+        throw new Error("OCR engine has been terminated.");
+      }
+      this.workers.push(...built);
+      this.idle.push(...built);
+    })().catch((err) => {
+      this.initPromise = null;
+      throw err;
+    });
+    return this.initPromise;
+  }
+
+  /** Create one fully-configured worker. Extracted as a seam so the pool lifecycle
+   *  (build/rollback/terminate) can be unit-tested without the real WASM engine. */
+  protected async spawnWorker(): Promise<TWorker> {
+    const tesseract = (this.tesseract ??= await import("tesseract.js"));
+    const corePath = resolveCorePath();
+    const worker = await tesseract.createWorker(this.lang, OEM_LSTM_ONLY, {
+      corePath,
+      langPath: this.langPath,
+      // "none": never touch a write-back cache; always read the local
+      // traineddata from langPath. Fully offline, no network fallback.
+      cacheMethod: "none",
+      gzip: false,
+      workerBlobURL: false,
+      legacyCore: false,
+      legacyLang: false,
+    });
+    // Treat each frame as one uniform block. On dense screen captures this
+    // recovers far more text than the default auto-segmentation (which drops
+    // regions it misjudges as non-text), maximizing recall for the blur pass.
+    await worker.setParameters({ tessedit_pageseg_mode: tesseract.PSM.SINGLE_BLOCK });
+    return worker;
+  }
+
+  /** Recognize words + boxes in one image (a JPEG file path or a Buffer). Throws on
+   *  engine failure so callers withhold the frame rather than treat a failed read as
+   *  "nothing to blur"; a successful read of a text-free image returns []. */
+  async recognize(image: string | Buffer): Promise<OcrWord[]> {
+    if (this.terminated) throw new Error("OCR engine has been terminated.");
+    await this.ensureInit();
+    const { input, scale } = await preprocessForOcr(image);
+    const worker = await this.acquire();
+    try {
+      const { data } = await worker.recognize(input, {}, { blocks: true });
+      return wordsFrom(data as unknown as RawPage, scale);
+    } catch (err) {
+      log.warn("recognize failed:", err instanceof Error ? err.message : err);
+      throw err instanceof Error ? err : new Error(String(err));
+    } finally {
+      this.release(worker);
+    }
+  }
+
+  private acquire(): Promise<TWorker> {
+    if (this.terminated) return Promise.reject(new Error("OCR engine has been terminated."));
+    const worker = this.idle.pop();
+    if (worker) return Promise.resolve(worker);
+    return new Promise<TWorker>((resolve, reject) => this.waiters.push({ resolve, reject }));
+  }
+
+  private release(worker: TWorker): void {
+    // If the pool was torn down while this recognition was in flight, the worker has
+    // already been terminated by terminate(); don't resurrect it into the idle set.
+    if (this.terminated) return;
+    const waiter = this.waiters.shift();
+    if (waiter) waiter.resolve(worker);
+    else this.idle.push(worker);
+  }
+
+  /** Tear down all workers (called when Advanced protection is disabled / on quit). */
+  async terminate(): Promise<void> {
+    this.terminated = true;
+    const workers = this.workers;
+    this.workers = [];
+    this.idle = [];
+    // Fail any queued recognitions right away so they withhold their frame instead of
+    // waiting on an in-flight (possibly hung) recognize to hand back a now-dead worker.
+    const pending = this.waiters.splice(0);
+    for (const waiter of pending) waiter.reject(new Error("OCR engine has been terminated."));
+    await Promise.all(workers.map((worker) => worker.terminate().catch(() => undefined)));
+  }
+}
+
+/** Flatten a recognition result to non-empty words with boxes. Word boxes are in
+ *  the OCR (possibly upscaled) image space; dividing by `scale` maps them back to
+ *  the source image's pixel coordinates so callers can blur the original frame. */
+function wordsFrom(page: RawPage, scale = 1): OcrWord[] {
+  const out: OcrWord[] = [];
+  for (const block of page.blocks ?? []) {
+    for (const para of block.paragraphs ?? []) {
+      for (const line of para.lines ?? []) {
+        for (const word of line.words ?? []) {
+          const text = (word.text ?? "").trim();
+          if (!text || !word.bbox) continue;
+          out.push({
+            text,
+            confidence: typeof word.confidence === "number" ? word.confidence : 0,
+            bbox: {
+              x0: word.bbox.x0 / scale,
+              y0: word.bbox.y0 / scale,
+              x1: word.bbox.x1 / scale,
+              y1: word.bbox.y1 / scale,
+            },
+          });
+        }
+      }
+    }
+  }
+  return out;
+}

--- a/electron/sensitive/scanner.test.ts
+++ b/electron/sensitive/scanner.test.ts
@@ -1,0 +1,276 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import type { SensitiveReport } from "../../common/sensitive";
+import { buildRedactor, loadSensitiveReport, saveSensitiveReport, scanSession } from "./scanner";
+
+const STARTED_AT = 10_000;
+
+// Fake, non-real values shaped to trip specific detectors.
+const GH_TOKEN = "ghp_" + "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8"; // 36 body chars
+const CARD = "4111 1111 1111 1111"; // Luhn-valid Visa test number
+const EMAIL = "dev@internal.example.com";
+const PERSON = "Ada Lovelace";
+
+function event(seq: number, offsetMs: number, type: string, payload: Record<string, unknown>) {
+  return JSON.stringify({
+    seq,
+    t: offsetMs,
+    epoch: STARTED_AT + offsetMs,
+    type,
+    source: "test",
+    payload,
+  });
+}
+
+async function seedSession(root: string, id: string): Promise<void> {
+  const dir = path.join(root, id);
+  await mkdir(dir, { recursive: true });
+
+  await writeFile(
+    path.join(dir, "session.json"),
+    JSON.stringify({ id, startedAt: STARTED_AT, stoppedAt: STARTED_AT + 9_000 }),
+  );
+
+  const lines = [
+    event(1, 1_500, "clipboard.change", { textPreview: `card ${CARD} for the test account` }),
+    event(2, 3_000, "terminal.command", { command: `echo ${GH_TOKEN}` }),
+    event(3, 2_500, "marker", { note: `met with ${PERSON} to review; ping ${EMAIL}` }),
+    event(4, 4_000, "app.title-change", { app: "Chrome", title: "Nothing sensitive here" }),
+    // Same GitHub token again, later — should dedupe into one finding (occurrences: 2).
+    event(5, 5_000, "terminal.command", { command: `echo ${GH_TOKEN}` }),
+  ];
+  await writeFile(path.join(dir, "events.jsonl"), lines.join("\n") + "\n");
+
+  await writeFile(
+    path.join(dir, "narration.json"),
+    JSON.stringify({
+      version: 1,
+      language: "en",
+      segments: [
+        { atMs: 6_000, text: `my email is ${EMAIL}` },
+        { atMs: 7_000, text: "nothing to see here" },
+      ],
+    }),
+  );
+}
+
+async function withSessionRoot(fn: (root: string) => Promise<void>): Promise<void> {
+  const root = await mkdtemp(path.join(tmpdir(), "skill-recorder-sensitive-"));
+  const previousRoot = process.env.SKILL_RECORDER_SESSIONS_DIR;
+  process.env.SKILL_RECORDER_SESSIONS_DIR = root;
+  try {
+    await fn(root);
+  } finally {
+    if (previousRoot === undefined) delete process.env.SKILL_RECORDER_SESSIONS_DIR;
+    else process.env.SKILL_RECORDER_SESSIONS_DIR = previousRoot;
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+test("scanSession detects secrets + structured PII across sources and returns raw values", async () => {
+  await withSessionRoot(async (root) => {
+    const id = "scan-test";
+    await seedSession(root, id);
+
+    const { report, values } = await scanSession(id);
+
+    assert.equal(report.sessionId, id);
+
+    // Secretlint finds the GitHub token; the two commands collapse to one finding
+    // seen twice, timed at the earliest occurrence (3_000, not 5_000).
+    const token = report.findings.find((f) => f.label === "GitHub token");
+    assert.ok(token, "expected a GitHub token finding");
+    assert.equal(token.occurrences, 2);
+    assert.equal(token.atMs, 3_000);
+    assert.equal(token.severity, "high");
+
+    // Structured PII (deterministic, in-repo).
+    assert.ok(report.findings.some((f) => f.category === "credit-card"), "expected a card finding");
+    assert.ok(report.findings.some((f) => f.category === "email"), "expected an email finding");
+
+    // Findings sort high-severity first.
+    assert.equal(report.findings[0].severity, "high");
+
+    // Raw values are returned to the main process (for the redactor) but never in
+    // the report itself.
+    assert.ok(values.includes(GH_TOKEN));
+    assert.ok(values.includes(CARD));
+    assert.ok(values.includes(EMAIL));
+
+    const serialized = JSON.stringify(report);
+    for (const raw of [GH_TOKEN, CARD, EMAIL]) {
+      assert.ok(!serialized.includes(raw), `report must not contain raw value: ${raw}`);
+    }
+    for (const f of report.findings) {
+      assert.match(f.redactedValue, /•/, "redacted value should be masked");
+    }
+  });
+});
+
+test("scanSession leaves personal names alone (NER layer removed)", async () => {
+  await withSessionRoot(async (root) => {
+    const id = "names-test";
+    await seedSession(root, id);
+
+    const { values } = await scanSession(id);
+    // The seeded marker note names a person; with the NER layer removed a bare name
+    // is neither detected nor added to the redaction values (secrets + PII only).
+    assert.ok(!values.includes(PERSON), "a bare name must not be a redaction value");
+  });
+});
+
+test("scanSession scans the whole event payload, not just primary fields", async () => {
+  await withSessionRoot(async (root) => {
+    const id = "payload-coverage";
+    const dir = path.join(root, id);
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      path.join(dir, "session.json"),
+      JSON.stringify({ id, startedAt: STARTED_AT, stoppedAt: STARTED_AT + 2_000 }),
+    );
+    // A secret that lives ONLY in a non-primary payload field — a terminal `cwd`,
+    // which get_events emits but the old curated scan (command-only) never read.
+    const CWD_TOKEN = "ghp_" + "Z9y8X7w6V5u4T3s2R1q0P9o8N7m6L5k4J3i2";
+    await writeFile(
+      path.join(dir, "events.jsonl"),
+      event(1, 500, "terminal.command", { command: "ls -la", cwd: `/srv/ci/${CWD_TOKEN}` }) + "\n",
+    );
+
+    const { report, values } = await scanSession(id);
+    assert.ok(values.includes(CWD_TOKEN), "a secret in a non-primary field must be redacted");
+    assert.ok(
+      report.findings.some((f) => f.source === "other"),
+      "a non-primary field's finding is sourced as 'other'",
+    );
+    assert.ok(!JSON.stringify(report).includes(CWD_TOKEN), "report must not carry the raw value");
+  });
+});
+
+test("scanSession does not leak an adjacent value through a sibling finding's snippet", async () => {
+  await withSessionRoot(async (root) => {
+    const id = "adjacent-values";
+    const dir = path.join(root, id);
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      path.join(dir, "session.json"),
+      JSON.stringify({ id, startedAt: STARTED_AT, stoppedAt: STARTED_AT + 2_000 }),
+    );
+    // Two emails close enough that each falls inside the other's ±32-char snippet
+    // window: each finding's snippet must mask BOTH, or one leaks raw as the other's
+    // "context". (Short values so the full neighbor fits in the window.)
+    const A = "alice@corp.example.com";
+    const B = "bob@corp.example.com";
+    await writeFile(
+      path.join(dir, "events.jsonl"),
+      event(1, 500, "marker", { note: `invite ${A} and ${B}` }) + "\n",
+    );
+
+    const { report } = await scanSession(id);
+    assert.ok(report.findings.length >= 2, "both emails should be found");
+    const serialized = JSON.stringify(report);
+    assert.ok(!serialized.includes(A), "first email must not leak (incl. as a neighbor's snippet)");
+    assert.ok(!serialized.includes(B), "second email must not leak (incl. as a neighbor's snippet)");
+  });
+});
+
+test("buildRedactor masks every detected value, longest first, and is a no-op when empty", async () => {
+  const redact = buildRedactor([GH_TOKEN, EMAIL, "ab"]); // "ab" below MIN_REDACT_LEN, ignored
+  const text = `token ${GH_TOKEN} mail ${EMAIL} ab`;
+  const out = redact(text);
+  assert.ok(!out.includes(GH_TOKEN));
+  assert.ok(!out.includes(EMAIL));
+  assert.ok(out.includes("••••"));
+  assert.ok(out.includes(" ab")); // short value left untouched
+
+  const noop = buildRedactor([]);
+  assert.equal(noop("nothing to redact here"), "nothing to redact here");
+});
+
+test("scanSession returns a clean result when nothing sensitive is present", async () => {
+  await withSessionRoot(async (root) => {
+    const id = "clean-test";
+    const dir = path.join(root, id);
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      path.join(dir, "session.json"),
+      JSON.stringify({ id, startedAt: STARTED_AT, stoppedAt: STARTED_AT + 1_000 }),
+    );
+    await writeFile(
+      path.join(dir, "events.jsonl"),
+      event(1, 500, "marker", { note: "reviewed the onboarding docs" }) + "\n",
+    );
+
+    const { report, values } = await scanSession(id);
+    assert.equal(report.totalFindings, 0);
+    assert.deepEqual(report.findings, []);
+    assert.deepEqual(values, []);
+  });
+});
+
+test("scanSession is defensive: missing artifacts yield an empty result, not a throw", async () => {
+  await withSessionRoot(async (root) => {
+    const id = "empty-test";
+    await mkdir(path.join(root, id), { recursive: true });
+    const { report, values } = await scanSession(id);
+    assert.equal(report.totalFindings, 0);
+    assert.deepEqual(report.findings, []);
+    assert.deepEqual(values, []);
+  });
+});
+
+const sampleReport = (id: string): SensitiveReport => ({
+  sessionId: id,
+  scannedAt: 123,
+  totalFindings: 1,
+  highSeverityCount: 1,
+  counts: { "api-key": 1 },
+  findings: [
+    {
+      category: "api-key",
+      label: "API key",
+      severity: "high",
+      source: "command",
+      redactedValue: "gh••••8",
+      snippet: "echo gh••••8",
+      atMs: 3_000,
+      occurrences: 1,
+    },
+  ],
+  images: { framesBlurred: 2, regionsBlurred: 3 },
+});
+
+test("saveSensitiveReport round-trips through loadSensitiveReport", async () => {
+  await withSessionRoot(async (root) => {
+    const id = "report-roundtrip";
+    await mkdir(path.join(root, id), { recursive: true });
+    const report = sampleReport(id);
+    saveSensitiveReport(id, report);
+    assert.deepEqual(loadSensitiveReport(id), report);
+  });
+});
+
+test("saveSensitiveReport(undefined) clears a previously written report", async () => {
+  await withSessionRoot(async (root) => {
+    const id = "report-clear";
+    await mkdir(path.join(root, id), { recursive: true });
+    saveSensitiveReport(id, sampleReport(id));
+    assert.notEqual(loadSensitiveReport(id), null);
+    saveSensitiveReport(id, undefined);
+    assert.equal(loadSensitiveReport(id), null);
+  });
+});
+
+test("loadSensitiveReport returns null for missing or malformed files", async () => {
+  await withSessionRoot(async (root) => {
+    const id = "report-bad";
+    const dir = path.join(root, id);
+    await mkdir(dir, { recursive: true });
+    assert.equal(loadSensitiveReport(id), null); // missing
+    await writeFile(path.join(dir, "sensitive-report.json"), '{"totalFindings":"nope"}');
+    assert.equal(loadSensitiveReport(id), null); // wrong shape
+  });
+});

--- a/electron/sensitive/scanner.ts
+++ b/electron/sensitive/scanner.ts
@@ -1,0 +1,265 @@
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import { NARRATION_FILE, type NarrationTranscript } from "../../common/narration";
+import {
+  maskValue,
+  redactedSnippet,
+  resolveOverlaps,
+  scanStructuredPii,
+  type SensitiveFinding,
+  type SensitiveMatch,
+  type SensitiveReport,
+  type SensitiveSource,
+} from "../../common/sensitive";
+import type { RecEvent, SessionMeta } from "../../common/types";
+import { readEvents } from "../frames/correlate";
+import { createLogger } from "../logger";
+import { isValidSessionId, sessionDir } from "../recorder/session-store";
+import { scanSecrets } from "./secrets";
+
+const log = createLogger("Sensitive");
+
+const SEVERITY_RANK = { high: 3, medium: 2, low: 1 } as const;
+
+/** Shortest value we bother redacting — below this, literal replacement would hit
+ *  too many innocent substrings elsewhere in the text. */
+const MIN_REDACT_LEN = 3;
+
+/** One string to scan, tagged with where it came from and when. */
+interface ScanField {
+  text: string;
+  source: SensitiveSource;
+  atMs: number | null;
+}
+
+/** The outcome of a scan: a redacted report for the UI plus the raw matched values
+ *  (main-process only — used to build the redactor; never sent to the renderer). */
+export interface ScanResult {
+  report: SensitiveReport;
+  /** De-duplicated raw values detected across the session. */
+  values: string[];
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === "string" && v.trim() ? v : undefined;
+}
+
+function readJson<T>(file: string): T | null {
+  if (!existsSync(file)) return null;
+  try {
+    return JSON.parse(readFileSync(file, "utf8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+/** Well-known (event type, payload key) → provenance, so common findings read
+ *  nicely in the report. Any *other* string field in the payload is still scanned
+ *  (tagged "other"): the detection surface deliberately covers the WHOLE payload,
+ *  matching what the describer's get_events tool can emit, so there is no curated
+ *  allow-list to silently drift out of sync with the outgoing data. */
+const KNOWN_FIELD_SOURCES: Record<string, Record<string, SensitiveSource>> = {
+  "app.activate": { title: "window-title", url: "url" },
+  "app.title-change": { title: "window-title" },
+  "browser.url": { url: "url", title: "window-title" },
+  "terminal.command": { command: "command" },
+  "clipboard.change": { textPreview: "clipboard" },
+  marker: { note: "note" },
+};
+
+/** Pull every scannable string field from one event's payload, tagged with
+ *  provenance + time. Scans the ENTIRE payload — not a hand-picked subset — so any
+ *  value get_events could surface (a path in `cwd`, a `host`, a window `path`, or
+ *  future PTY output) is covered by the pre-send redaction, not just the primary
+ *  fields. Non-string fields (numbers, bounds, format lists) carry no free text. */
+function fieldsFromEvent(ev: RecEvent, startedAt: number | null): ScanField[] {
+  const atMs = startedAt != null ? ev.epoch - startedAt : null;
+  const known = KNOWN_FIELD_SOURCES[ev.type];
+  const fields: ScanField[] = [];
+  for (const [key, value] of Object.entries(ev.payload)) {
+    const text = str(value);
+    if (!text) continue;
+    fields.push({ text, source: known?.[key] ?? "other", atMs });
+  }
+  return fields;
+}
+
+/** Every scannable text field of a recording, in timeline order. */
+function collectFields(dir: string): ScanField[] {
+  const fields: ScanField[] = [];
+
+  const meta = readJson<SessionMeta>(path.join(dir, "session.json"));
+  const startedAt = typeof meta?.startedAt === "number" ? meta.startedAt : null;
+
+  let events: RecEvent[] = [];
+  try {
+    events = readEvents(path.join(dir, "events.jsonl"));
+  } catch (err) {
+    log.warn("could not read events for scan:", err instanceof Error ? err.message : err);
+  }
+  for (const ev of events) fields.push(...fieldsFromEvent(ev, startedAt));
+
+  const narration = readJson<NarrationTranscript>(path.join(dir, NARRATION_FILE));
+  if (narration && Array.isArray(narration.segments)) {
+    for (const seg of narration.segments) {
+      const text = str(seg?.text);
+      if (text) {
+        fields.push({
+          text,
+          source: "narration",
+          atMs: typeof seg.atMs === "number" ? seg.atMs : null,
+        });
+      }
+    }
+  }
+
+  return fields;
+}
+
+/** Run every detection layer over one string and merge them (overlaps resolved). */
+async function matchesFor(text: string): Promise<SensitiveMatch[]> {
+  const secrets = await scanSecrets(text);
+  const pii = scanStructuredPii(text);
+  return resolveOverlaps([...secrets, ...pii]);
+}
+
+/** Stable identity for deduping the same value seen in the same kind of place. */
+function findingKey(source: SensitiveSource, match: SensitiveMatch): string {
+  return `${source}|${match.category}|${match.value}`;
+}
+
+/**
+ * Scan one recording for potentially sensitive details in the text that Analyze
+ * would send to GitHub Copilot. Scans EVERY string field of every recorded event
+ * — the whole payload, not a curated subset — because the describer's get_events
+ * tool can surface any payload field (window titles, URLs, clipboard previews,
+ * commands, cwd/host/path, markers…); plus transcribed voice narration. Runs the
+ * secret + structured-PII detection layers over each field.
+ *
+ * Runs entirely on this computer and is best-effort / non-throwing — an unreadable
+ * artifact simply contributes no fields. Returns a redacted {@link SensitiveReport}
+ * (masked values + short redacted context only) plus the raw matched `values` for
+ * the caller's redactor. The report NEVER carries raw values; the `values` array
+ * stays in the main process and is never persisted or sent to the renderer.
+ *
+ * Note: this inspects text only. Secrets merely *visible* in screen frames are
+ * handled separately by the frame OCR + blur seam in the describer's get_frames.
+ */
+export async function scanSession(sessionId: string): Promise<ScanResult> {
+  const dir = sessionDir(sessionId); // throws on an unsafe id (traversal guard)
+  const fields = collectFields(dir);
+
+  const byKey = new Map<string, SensitiveFinding>();
+  const values = new Set<string>();
+  // Payload fields repeat verbatim across events (app name, cwd, host, url), so
+  // cache detector results by exact text to avoid re-scanning identical strings.
+  const scanCache = new Map<string, SensitiveMatch[]>();
+  for (const field of fields) {
+    let matches = scanCache.get(field.text);
+    if (!matches) {
+      try {
+        matches = await matchesFor(field.text);
+      } catch (err) {
+        log.warn("field scan failed:", err instanceof Error ? err.message : err);
+        continue;
+      }
+      scanCache.set(field.text, matches);
+    }
+    for (const match of matches) {
+      if (match.value.length >= MIN_REDACT_LEN) values.add(match.value);
+      const key = findingKey(field.source, match);
+      const existing = byKey.get(key);
+      if (existing) {
+        existing.occurrences += 1;
+        // Keep the earliest known time so the finding points at first exposure.
+        if (field.atMs != null && (existing.atMs == null || field.atMs < existing.atMs)) {
+          existing.atMs = field.atMs;
+        }
+        continue;
+      }
+      byKey.set(key, {
+        category: match.category,
+        label: match.label,
+        severity: match.severity,
+        source: field.source,
+        redactedValue: maskValue(match.value),
+        snippet: redactedSnippet(field.text, match, matches),
+        atMs: field.atMs,
+        occurrences: 1,
+      });
+    }
+  }
+
+  const findings = [...byKey.values()].sort((a, b) => {
+    const sev = SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity];
+    if (sev !== 0) return sev;
+    const at = (a.atMs ?? Infinity) - (b.atMs ?? Infinity);
+    if (at !== 0) return at;
+    return a.label.localeCompare(b.label);
+  });
+
+  const counts: SensitiveReport["counts"] = {};
+  for (const f of findings) counts[f.category] = (counts[f.category] ?? 0) + 1;
+
+  const report: SensitiveReport = {
+    sessionId,
+    scannedAt: Date.now(),
+    totalFindings: findings.length,
+    highSeverityCount: findings.filter((f) => f.severity === "high").length,
+    counts,
+    findings,
+  };
+  return { report, values: [...values] };
+}
+
+/**
+ * Build a redactor that replaces every detected raw value with its mask. Literal,
+ * longest-first replacement so a value contained in another (e.g. a token inside a
+ * URL) is masked as the longer match first. Values shorter than MIN_REDACT_LEN are
+ * ignored to avoid masking innocent substrings.
+ */
+export function buildRedactor(values: string[]): (text: string) => string {
+  const unique = [...new Set(values.filter((v) => v.length >= MIN_REDACT_LEN))].sort(
+    (a, b) => b.length - a.length,
+  );
+  if (unique.length === 0) return (text) => text;
+  return (text) => {
+    let out = text;
+    for (const value of unique) {
+      if (out.includes(value)) out = out.split(value).join(maskValue(value));
+    }
+    return out;
+  };
+}
+
+/** Where the (raw-value-free) UI summary is cached per session. */
+const SENSITIVE_REPORT_FILE = "sensitive-report.json";
+
+/**
+ * Persist the redaction summary next to the analysis so the review survives app
+ * restarts and navigation (the live {@link SensitiveReport} is otherwise transient).
+ * Passing `undefined` (protection off / nothing hidden) clears any stale summary so
+ * a later "nothing found" re-analysis doesn't resurface an old report. The report
+ * already carries only masked values + counts, so this never writes raw secrets.
+ * Best-effort: a write failure must never break Analyze.
+ */
+export function saveSensitiveReport(sessionId: string, report: SensitiveReport | undefined): void {
+  if (!isValidSessionId(sessionId)) return;
+  const file = path.join(sessionDir(sessionId), SENSITIVE_REPORT_FILE);
+  try {
+    if (report) writeFileSync(file, JSON.stringify(report, null, 2));
+    else rmSync(file, { force: true });
+  } catch (err) {
+    log.warn("failed to persist sensitive report:", err);
+  }
+}
+
+/** Load a persisted redaction summary for a session, or null when there is none
+ *  (or the file is missing/corrupt). Shape-guarded so a bad file can't crash the UI. */
+export function loadSensitiveReport(sessionId: string): SensitiveReport | null {
+  if (!isValidSessionId(sessionId)) return null;
+  const raw = readJson<SensitiveReport>(path.join(sessionDir(sessionId), SENSITIVE_REPORT_FILE));
+  if (!raw || typeof raw.totalFindings !== "number" || !Array.isArray(raw.findings)) return null;
+  return raw;
+}

--- a/electron/sensitive/secretlint-config.ts
+++ b/electron/sensitive/secretlint-config.ts
@@ -1,0 +1,145 @@
+// Pure configuration + message-mapping for the secretlint detection layer.
+//
+// This module has NO runtime dependency on secretlint — it only imports types —
+// so it can be unit-tested in isolation. `secrets.ts` dynamically imports the
+// actual `@secretlint/core` engine and the rule creators, passes the creators to
+// {@link buildSecretlintConfig}, and maps each reported message back to a
+// {@link SensitiveMatch} via {@link mapSecretlintMessage}.
+
+import type {
+  SecretLintCoreConfig,
+  SecretLintCoreResultMessage,
+  SecretLintRuleCreator,
+  SecretLintRulePresetCreator,
+} from "@secretlint/types";
+
+import type { SensitiveCategory, SensitiveMatch, SensitiveSeverity } from "../../common/sensitive";
+
+/** Secrets always outrank structured PII (40–55) when two matches overlap the
+ *  same span — a leaked credential is the worst case. */
+const SECRET_RANK = 90;
+const SECRET_SEVERITY: SensitiveSeverity = "high";
+
+const PRESET_RULE_ID = "@secretlint/secretlint-rule-preset-recommend";
+const PATTERN_RULE_ID = "@secretlint/secretlint-rule-pattern";
+const AWS_RULE_ID = "@secretlint/secretlint-rule-aws";
+
+/**
+ * JSON Web Token: `header.payload.signature`, each a base64url segment, the first
+ * two beginning with the `{"` prefix that base64url-encodes to `eyJ`. The preset
+ * does not catch bare JWTs, so we add this via the pattern rule.
+ */
+const JWT_PATTERN = "eyJ[A-Za-z0-9_-]{8,}\\.eyJ[A-Za-z0-9_-]{6,}\\.[A-Za-z0-9_-]{6,}";
+const JWT_PATTERN_NAME = "JSON Web Token";
+
+interface CategoryLabel {
+  category: SensitiveCategory;
+  label: string;
+}
+
+/**
+ * Map a secretlint rule id to our category + human label. The preset bundles 28
+ * provider rules; nearly all are API keys/tokens. Private keys and credential
+ * pairs get their own categories so the review UI can group them meaningfully.
+ * Unknown ids fall back to a generic API-key label.
+ */
+const RULE_MAP: Record<string, CategoryLabel> = {
+  "@secretlint/secretlint-rule-privatekey": { category: "private-key", label: "Private key" },
+  "@secretlint/secretlint-rule-basicauth": { category: "password", label: "Basic-auth credentials" },
+  "@secretlint/secretlint-rule-database-connection-string": {
+    category: "password",
+    label: "Database connection string",
+  },
+  [PATTERN_RULE_ID]: { category: "jwt", label: JWT_PATTERN_NAME },
+  [AWS_RULE_ID]: { category: "api-key", label: "AWS credential" },
+  "@secretlint/secretlint-rule-gcp": { category: "api-key", label: "Google Cloud key" },
+  "@secretlint/secretlint-rule-github": { category: "api-key", label: "GitHub token" },
+  "@secretlint/secretlint-rule-gitlab": { category: "api-key", label: "GitLab token" },
+  "@secretlint/secretlint-rule-openai": { category: "api-key", label: "OpenAI API key" },
+  "@secretlint/secretlint-rule-anthropic": { category: "api-key", label: "Anthropic API key" },
+  "@secretlint/secretlint-rule-slack": { category: "api-key", label: "Slack token" },
+  "@secretlint/secretlint-rule-stripe": { category: "api-key", label: "Stripe key" },
+  "@secretlint/secretlint-rule-sendgrid": { category: "api-key", label: "SendGrid API key" },
+  "@secretlint/secretlint-rule-npm": { category: "api-key", label: "npm token" },
+  "@secretlint/secretlint-rule-shopify": { category: "api-key", label: "Shopify token" },
+  "@secretlint/secretlint-rule-huggingface": { category: "api-key", label: "Hugging Face token" },
+  "@secretlint/secretlint-rule-notion": { category: "api-key", label: "Notion token" },
+  "@secretlint/secretlint-rule-linear": { category: "api-key", label: "Linear API key" },
+  "@secretlint/secretlint-rule-figma": { category: "api-key", label: "Figma token" },
+  "@secretlint/secretlint-rule-cloudflare": { category: "api-key", label: "Cloudflare token" },
+  "@secretlint/secretlint-rule-databricks": { category: "api-key", label: "Databricks token" },
+  "@secretlint/secretlint-rule-docker": { category: "password", label: "Docker credentials" },
+  "@secretlint/secretlint-rule-grafana": { category: "api-key", label: "Grafana token" },
+  "@secretlint/secretlint-rule-groq": { category: "api-key", label: "Groq API key" },
+  "@secretlint/secretlint-rule-hashicorp-vault": {
+    category: "api-key",
+    label: "HashiCorp Vault token",
+  },
+  "@secretlint/secretlint-rule-tailscale": { category: "api-key", label: "Tailscale key" },
+  "@secretlint/secretlint-rule-vercel": { category: "api-key", label: "Vercel token" },
+  "@secretlint/secretlint-rule-1password": { category: "api-key", label: "1Password token" },
+};
+
+/** Best category + label for a reported message, preferring the specific rule id
+ *  and falling back to the preset parent, then to a generic secret label. */
+function categoryFor(message: SecretLintCoreResultMessage): CategoryLabel {
+  return (
+    RULE_MAP[message.ruleId] ??
+    (message.ruleParentId ? RULE_MAP[message.ruleParentId] : undefined) ?? {
+      category: "api-key",
+      label: "Secret or token",
+    }
+  );
+}
+
+/**
+ * Convert one secretlint result message into a {@link SensitiveMatch}, slicing the
+ * raw value straight out of the scanned `content` via the message range so we never
+ * depend on secretlint's (possibly masked) message text. Returns null for an empty
+ * or out-of-bounds range.
+ */
+export function mapSecretlintMessage(
+  message: SecretLintCoreResultMessage,
+  content: string,
+): SensitiveMatch | null {
+  const [start, end] = message.range;
+  if (
+    !Number.isFinite(start) ||
+    !Number.isFinite(end) ||
+    start < 0 ||
+    end > content.length ||
+    end <= start
+  ) {
+    return null;
+  }
+  const value = content.slice(start, end);
+  if (!value.trim()) return null;
+  const { category, label } = categoryFor(message);
+  return { category, label, severity: SECRET_SEVERITY, value, start, end, rank: SECRET_RANK };
+}
+
+/**
+ * Build the in-process secretlint config from the dynamically-imported rule
+ * creators. Enables the preset's AWS access-key-ID scan (off by default) — with
+ * non-blocking auto-redaction a false positive is cheap and a missed AWS key is
+ * expensive — and adds a JWT pattern the preset doesn't cover.
+ */
+export function buildSecretlintConfig(
+  presetCreator: SecretLintRulePresetCreator,
+  patternCreator: SecretLintRuleCreator,
+): SecretLintCoreConfig {
+  return {
+    rules: [
+      {
+        id: PRESET_RULE_ID,
+        rule: presetCreator,
+        rules: [{ id: AWS_RULE_ID, options: { enableIDScanRule: true } }],
+      },
+      {
+        id: PATTERN_RULE_ID,
+        rule: patternCreator,
+        options: { patterns: [{ name: JWT_PATTERN_NAME, pattern: `/${JWT_PATTERN}/g` }] },
+      },
+    ],
+  };
+}

--- a/electron/sensitive/secrets.test.ts
+++ b/electron/sensitive/secrets.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { scanSecrets } from "./secrets";
+
+// Fake, non-real credentials shaped to trip the bundled secretlint preset rules.
+const GH_TOKEN = "ghp_" + "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8"; // exactly 36 body chars
+const JWT =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+  "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4ifQ." +
+  "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+
+test("detects a GitHub token as a high-severity secret", async () => {
+  const matches = await scanSecrets(`run: echo ${GH_TOKEN}`);
+  const hit = matches.find((m) => m.value === GH_TOKEN);
+  assert.ok(hit, "expected the GitHub token to be detected");
+  assert.equal(hit.severity, "high");
+  assert.equal(hit.category, "api-key");
+  // Offsets point at the raw value in the original text.
+  assert.equal(hit.value, `run: echo ${GH_TOKEN}`.slice(hit.start, hit.end));
+});
+
+test("detects a JSON Web Token", async () => {
+  const matches = await scanSecrets(`Authorization: Bearer ${JWT}`);
+  assert.ok(matches.some((m) => m.category === "jwt"), "expected a JWT finding");
+});
+
+test("does not flag ordinary prose (no false positives)", async () => {
+  const matches = await scanSecrets(
+    "Opened the quarterly planning doc, reviewed the roadmap, and closed three issues.",
+  );
+  assert.deepEqual(matches, []);
+});
+
+test("is non-throwing and returns [] for empty input", async () => {
+  assert.deepEqual(await scanSecrets(""), []);
+});

--- a/electron/sensitive/secrets.ts
+++ b/electron/sensitive/secrets.ts
@@ -1,0 +1,74 @@
+// Secret/credential detection layer. Wraps `@secretlint/core` — an
+// offline, in-process linter — behind a small async surface that returns
+// {@link SensitiveMatch}es for a single string. The engine and rule creators are
+// imported dynamically so secretlint (and its large rule set) is only loaded the
+// first time a scan actually runs, not at app startup.
+
+import type { SecretLintCoreConfig, SecretLintCoreResult } from "@secretlint/types";
+
+import type { SensitiveMatch } from "../../common/sensitive";
+import { createLogger } from "../logger";
+import { buildSecretlintConfig, mapSecretlintMessage } from "./secretlint-config";
+
+const log = createLogger("Sensitive/secrets");
+
+type LintSource = (args: {
+  source: { content: string; filePath: string; ext?: string; contentType: "text" };
+  options: { config: SecretLintCoreConfig; maskSecrets?: boolean };
+}) => Promise<SecretLintCoreResult>;
+
+interface Engine {
+  lintSource: LintSource;
+  config: SecretLintCoreConfig;
+}
+
+let enginePromise: Promise<Engine | null> | null = null;
+
+/** Load the core engine + rule creators once and build the config. Memoized; on
+ *  failure it resolves null and future calls retry from scratch. */
+async function getEngine(): Promise<Engine | null> {
+  if (!enginePromise) {
+    enginePromise = (async () => {
+      const [core, preset, pattern] = await Promise.all([
+        import("@secretlint/core"),
+        import("@secretlint/secretlint-rule-preset-recommend"),
+        import("@secretlint/secretlint-rule-pattern"),
+      ]);
+      const config = buildSecretlintConfig(preset.creator, pattern.creator);
+      return { lintSource: core.lintSource as LintSource, config };
+    })().catch((err) => {
+      log.warn("secretlint failed to load:", err instanceof Error ? err.message : err);
+      enginePromise = null;
+      return null;
+    });
+  }
+  return enginePromise;
+}
+
+/**
+ * Scan one string for secrets/credentials. Best-effort and non-throwing: any
+ * engine failure yields no matches (the structured-PII layer still
+ * runs). Returns raw matches (rank 90); the caller merges layers and resolves
+ * overlaps. Never logs or returns the raw value except inside the match's
+ * in-memory `value` field.
+ */
+export async function scanSecrets(text: string): Promise<SensitiveMatch[]> {
+  if (!text || !text.trim()) return [];
+  const engine = await getEngine();
+  if (!engine) return [];
+  try {
+    const result = await engine.lintSource({
+      source: { content: text, filePath: "session.txt", ext: ".txt", contentType: "text" },
+      options: { config: engine.config, maskSecrets: true },
+    });
+    const matches: SensitiveMatch[] = [];
+    for (const message of result.messages) {
+      const match = mapSecretlintMessage(message, text);
+      if (match) matches.push(match);
+    }
+    return matches;
+  } catch (err) {
+    log.warn("secret scan failed:", err instanceof Error ? err.message : err);
+    return [];
+  }
+}

--- a/electron/sensitive/tessdata-source.test.ts
+++ b/electron/sensitive/tessdata-source.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { test } from "node:test";
+
+import {
+  assertSha256,
+  TESSDATA_COMMIT,
+  TESSDATA_SHA256,
+  tessdataFileName,
+  tessdataUrl,
+  verifyTessdata,
+} from "./tessdata-source";
+
+test("tessdataUrl pins an immutable commit, never the mutable main branch", () => {
+  const url = tessdataUrl("eng");
+  assert.match(url, /tessdata_fast\/[0-9a-f]{40}\/eng\.traineddata$/);
+  assert.ok(url.includes(TESSDATA_COMMIT));
+  assert.ok(!url.includes("/main/"), "URL must not track the mutable main branch");
+});
+
+test("tessdataFileName maps a code to its .traineddata file", () => {
+  assert.equal(tessdataFileName("eng"), "eng.traineddata");
+});
+
+test("the pinned eng digest is a 64-char hex SHA-256", () => {
+  assert.match(TESSDATA_SHA256.eng, /^[0-9a-f]{64}$/);
+});
+
+test("assertSha256 passes when the bytes hash to the expected digest", () => {
+  const data = Buffer.from("hello tessdata");
+  const digest = createHash("sha256").update(data).digest("hex");
+  assert.doesNotThrow(() => assertSha256("test data", data, digest));
+});
+
+test("assertSha256 throws when the bytes do not hash to the expected digest", () => {
+  const data = Buffer.from("hello tessdata");
+  const wrong = createHash("sha256").update("something else").digest("hex");
+  assert.throws(() => assertSha256("test data", data, wrong), /failed its integrity check/);
+});
+
+test("verifyTessdata throws when the downloaded bytes do not match the pinned digest", () => {
+  assert.throws(
+    () => verifyTessdata("eng", Buffer.from("tampered content")),
+    /failed its integrity check/,
+  );
+});
+
+test("verifyTessdata fails closed for a language with no pinned checksum", () => {
+  assert.throws(() => verifyTessdata("zzz", Buffer.from("anything")), /No pinned checksum/);
+});

--- a/electron/sensitive/tessdata-source.ts
+++ b/electron/sensitive/tessdata-source.ts
@@ -1,0 +1,49 @@
+// Pinned, integrity-checked source for the Tesseract `tessdata_fast` language data
+// that Advanced protection downloads. Kept free of any electron/runtime imports so it
+// can be unit-tested directly. The URL is pinned to an immutable commit (not the
+// mutable `main` branch) and every download is verified against a known SHA-256 before
+// it is written to disk or handed to the Tesseract WASM parser, so a compromised or
+// altered CDN response can never be cached or loaded.
+
+import { createHash } from "node:crypto";
+
+/** The (uncompressed) Tesseract language model filename for a tessdata code. */
+export function tessdataFileName(code: string): string {
+  return `${code}.traineddata`;
+}
+
+/** Immutable `tessdata_fast` commit (tag 4.1.0) the language data is pinned to. Using a
+ *  commit SHA instead of `main` makes the fetched bytes reproducible and lets us verify
+ *  them against the digests below; bump both together when intentionally upgrading. */
+export const TESSDATA_COMMIT = "65727574dfcd264acbb0c3e07860e4e9e9b22185";
+
+/** SHA-256 of each shipped `<code>.traineddata` at {@link TESSDATA_COMMIT}. A download is
+ *  rejected unless its bytes match, so altered content is never written or parsed. */
+export const TESSDATA_SHA256: Readonly<Record<string, string>> = {
+  eng: "7d4322bd2a7749724879683fc3912cb542f19906c83bcc1a52132556427170b2",
+};
+
+/** Pinned raw URL for a language's tessdata file. */
+export function tessdataUrl(code: string): string {
+  return `https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/${TESSDATA_COMMIT}/${tessdataFileName(code)}`;
+}
+
+/** Throw unless `data` hashes (SHA-256) to `expectedHex`. Pure and side-effect free so
+ *  both the pass and fail branches are directly unit-testable. */
+export function assertSha256(label: string, data: Buffer, expectedHex: string): void {
+  const actual = createHash("sha256").update(data).digest("hex");
+  if (actual !== expectedHex)
+    throw new Error(
+      `${label} failed its integrity check ` +
+        `(expected ${expectedHex.slice(0, 12)}…, got ${actual.slice(0, 12)}…).`,
+    );
+}
+
+/** Assert downloaded tessdata bytes match the pinned digest. Throws on mismatch or on an
+ *  unpinned code (fail closed) so unverifiable data is never used. */
+export function verifyTessdata(code: string, data: Buffer): void {
+  const expected = TESSDATA_SHA256[code];
+  if (!expected)
+    throw new Error(`No pinned checksum for OCR language "${code}"; refusing to use it.`);
+  assertSha256(`OCR language data for "${code}"`, data, expected);
+}

--- a/electron/window.ts
+++ b/electron/window.ts
@@ -13,8 +13,14 @@ import { windowIcon } from "./icons";
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
-/** Compact recording HUD — fixed footprint, never resizes. */
-const RECORDER = { width: 400, height: 534 };
+/** Compact recording HUD — fixed width; height auto-fits its content (see
+ *  `fitRecorderHeight`). The initial height is a sensible first paint before the
+ *  renderer reports its true content height. */
+const RECORDER = { width: 400, height: 500 };
+/** Guard rails for the content-driven height so a bad measurement can't produce a
+ *  degenerate window. */
+const RECORDER_MIN_HEIGHT = 320;
+const RECORDER_MAX_HEIGHT = 720;
 /** Library sizing bounds; actual width adapts to the space beside the recorder. */
 const LIBRARY = { desiredWidth: 1140, minWidth: 720, floorWidth: 520, maxHeight: 820 };
 const MARGIN = 12;
@@ -62,6 +68,26 @@ export function createRecorderWindow(): BrowserWindow {
   registerDevelopmentDevToolsShortcut(win);
   loadRoute(win);
   return win;
+}
+
+/**
+ * Fit the recorder window to the height the renderer reports for its content, so the
+ * fixed-width HUD shows neither dead space (short states) nor a clipped row (when the
+ * doctor reveals an extra model row). The width is preserved; the top-left is kept so
+ * it grows/shrinks downward. `resizable:false` blocks user resizing but not this
+ * programmatic sizing — on platforms that also block that, we briefly re-enable it.
+ */
+export function fitRecorderHeight(win: BrowserWindow, contentHeight: number): void {
+  if (win.isDestroyed() || !Number.isFinite(contentHeight)) return;
+  const target = Math.round(
+    Math.max(RECORDER_MIN_HEIGHT, Math.min(RECORDER_MAX_HEIGHT, contentHeight)),
+  );
+  const [width, current] = win.getContentSize();
+  if (Math.abs(current - target) < 1) return;
+  const wasResizable = win.isResizable();
+  if (!wasResizable) win.setResizable(true);
+  win.setContentSize(width, target);
+  if (!wasResizable) win.setResizable(false);
 }
 
 /** Always-on-top recording transport shown without stealing focus from the task. */

--- a/evals/README.md
+++ b/evals/README.md
@@ -220,6 +220,70 @@ the web hosts are forbidden: `cowork-teams-digest` (read a channel then post via
 `m365_teams`), `cowork-outlook-reply` (triage the mailbox then reply via `outlook`), and
 `cowork-calendar-schedule` (find a slot then book via `outlook_calendar`).
 
+## Sensitive detection + redaction evals (`evals/sensitive/`)
+
+Guards the **on-device sanitization pipeline** that runs before anything is sent to
+GitHub Copilot on Analyze: the two detection layers (secretlint secrets · our
+in-repo structured-PII regex) and the two redaction seams (masking outgoing
+**text** channels, and OCR + blur of on-screen values in **frames** under Advanced
+protection).
+
+```bash
+npm run eval:sensitive                 # all cases (text + frames)
+npm run eval:sensitive -- --only=jwt,frame-card-split
+npm run eval:sensitive -- --verbose    # also print the redacted text / blur summary
+```
+
+Unlike the describer/builder harnesses this one is **fully deterministic — no LLM,
+no model weights, no network** (exit code non-zero on any failure). secretlint and
+our regex run for real; the frame layer supplies OCR words + boxes directly (no
+tesseract/sharp) so the box-mapping is exercised offline.
+
+**Corpus.**
+- `corpus.ts` — one outgoing text string per case with two ground-truth lists:
+  `mustRedact` (values that must be masked — recall) and `mustKeep` (ordinary text
+  that must survive — precision). Covers every secret type, each structured-PII
+  detector **and its validators** (Luhn-invalid card / invalid-area SSN are *not*
+  flagged), a check that personal names are **not** redacted (the names layer was
+  dropped), multi-detector strings, and clean prose/URLs/hashes.
+- `frames.ts` — synthetic OCR word layouts with the sensitive words flagged. Covers
+  a secret/email on screen, a card split across four OCR tokens (all four blur), a
+  session value known from clean text blurred across OCR words (cross-feed), and a
+  clean frame (nothing blurred).
+
+**Rubric** (`score.ts`): a text case runs the real detectors → `redactText` and
+checks every `mustRedact` value is gone from the output while every `mustKeep`
+value survives (clean cases must yield zero findings). A frame case runs the real
+`sensitiveFrameBoxes` and checks exactly the sensitive words' boxes are selected.
+The summary reports aggregate **recall** (sensitive detail masked/blurred) and
+**precision** (ordinary content kept).
+
+### Opt-in real-image OCR eval (`ocr-images.ts`)
+
+The deterministic frame eval above feeds *synthetic* OCR words, so it can't catch
+the real leak vector: Tesseract **misreading** on-screen text badly enough that a
+value is never detected (and the frame ships unblurred). This separate, **non-hermetic**
+harness closes that gap end-to-end — it renders text to actual JPEGs with `sharp`,
+runs the **real `Ocr` engine** + the shared detectors via `sensitiveFrameBoxes`, and
+checks each sensitive line gets a blur box while clean lines are left alone.
+
+```bash
+npm run eval:sensitive:ocr             # renders text → JPEG, real Tesseract (English)
+npm run eval:sensitive:ocr -- --keep   # also print each case's recognized OCR text
+```
+
+It is **not** part of `eval:sensitive`: it needs the tesseract WASM core, `sharp`
+with system fonts, and a one-time `tessdata_fast` download per language (cached in
+the git-ignored `evals/.cache/tessdata/`). When the environment can't support it
+(no fonts / no network / OCR can't read a probe image) it **self-skips with exit 0**
+rather than failing. Scoring is layout-based and OCR-jitter tolerant: each line is
+rendered in its own fixed-height band, recall = "a blur box lands on a sensitive
+line", precision = "no box lands on a clean line". Cases cover a GitHub token, a
+credit card + email, a known-value cross-feed, and a Latin email amid Japanese text
+read with **English-only** traineddata (the ASCII value is recognized and blurred
+even though the surrounding Japanese OCRs to garbage — validating the eng-only
+product decision).
+
 ## Mock pages (`evals/mocks/`)
 
 Static, self-contained HTML fixtures matching the scenarios (`pricing.html`,

--- a/evals/sensitive/corpus.ts
+++ b/evals/sensitive/corpus.ts
@@ -1,0 +1,145 @@
+// Fixed corpus for the sensitive-detail detection + redaction evals.
+//
+// Each case is a single outgoing text string plus two ground-truth lists:
+//   - mustRedact: raw substrings that MUST be detected and masked out before the
+//     text could be sent to GitHub Copilot (recall).
+//   - mustKeep: non-sensitive substrings that MUST survive redaction untouched
+//     (precision — guards against over-masking ordinary prose).
+//
+// All secrets/PII here are FAKE, shaped only to trip the detectors.
+
+export interface SensitiveCase {
+  id: string;
+  /** What this case exercises, for the report. */
+  about: string;
+  text: string;
+  mustRedact: string[];
+  mustKeep: string[];
+}
+
+const GH_TOKEN = "ghp_" + "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8";
+const OPENAI = "sk-" + "A".repeat(20) + "T3BlbkFJ" + "B".repeat(20);
+const SLACK = "xoxb-" + "1".repeat(12) + "-" + "2".repeat(12) + "-" + "abcdefghijklmnopqrstuvwx";
+const JWT =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+  "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4ifQ." +
+  "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+
+export const sensitiveCorpus: SensitiveCase[] = [
+  {
+    id: "github-token",
+    about: "GitHub token in a terminal command (secretlint)",
+    text: `git push && echo ${GH_TOKEN} | pbcopy`,
+    mustRedact: [GH_TOKEN],
+    mustKeep: ["git push", "pbcopy"],
+  },
+  {
+    id: "openai-key",
+    about: "OpenAI API key in an env assignment (secretlint)",
+    text: `export OPENAI_API_KEY=${OPENAI} && run agent`,
+    mustRedact: [OPENAI],
+    mustKeep: ["export OPENAI_API_KEY=", "run agent"],
+  },
+  {
+    id: "slack-token",
+    about: "Slack bot token (secretlint)",
+    text: `curl -H "Authorization: Bearer ${SLACK}" https://slack.com/api/auth.test`,
+    mustRedact: [SLACK],
+    mustKeep: ["slack.com/api/auth.test"],
+  },
+  {
+    id: "jwt",
+    about: "JSON Web Token in an Authorization header (secretlint)",
+    text: `Authorization: Bearer ${JWT}`,
+    mustRedact: [JWT],
+    mustKeep: ["Authorization: Bearer"],
+  },
+  {
+    id: "basic-auth-url",
+    about: "Credentials embedded in a URL (secretlint)",
+    text: "clone https://svc:S3cretPass99@git.internal.example.com/repo.git now",
+    mustRedact: ["S3cretPass99"],
+    mustKeep: ["clone ", "/repo.git now"],
+  },
+  {
+    id: "email",
+    about: "Email address (structured PII)",
+    text: "ping the owner at jane.doe@example.com about the incident",
+    mustRedact: ["jane.doe@example.com"],
+    mustKeep: ["ping the owner at", "about the incident"],
+  },
+  {
+    id: "credit-card",
+    about: "Luhn-valid payment card number (structured PII)",
+    text: "Order #1024 paid with card 4111 1111 1111 1111 on file",
+    mustRedact: ["4111 1111 1111 1111"],
+    mustKeep: ["Order #1024", "on file"],
+  },
+  {
+    id: "ssn",
+    about: "US Social Security number (structured PII)",
+    text: "employee SSN 123-45-6789 recorded in the HR sheet",
+    mustRedact: ["123-45-6789"],
+    mustKeep: ["employee", "recorded in the HR sheet"],
+  },
+  {
+    id: "phone",
+    about: "North-American phone number (structured PII)",
+    text: "call the desk at 415-555-0132 before noon",
+    mustRedact: ["415-555-0132"],
+    mustKeep: ["call the desk at", "before noon"],
+  },
+  {
+    id: "phone-e164",
+    about: "International E.164 phone number (structured PII)",
+    text: "reach the London office at +44 20 7946 0958 anytime",
+    mustRedact: ["+44 20 7946 0958"],
+    mustKeep: ["reach the London office at", "anytime"],
+  },
+  {
+    id: "credit-card-invalid",
+    about: "Card-shaped number that fails the Luhn check — NOT flagged (precision)",
+    text: "internal ref 4111 1111 1111 1112 logged for the batch job",
+    mustRedact: [],
+    mustKeep: ["4111 1111 1111 1112", "logged for the batch job"],
+  },
+  {
+    id: "ssn-invalid",
+    about: "SSN-shaped number with an invalid area (666) — NOT flagged (precision)",
+    text: "tracking code 666-12-3456 is just an internal id",
+    mustRedact: [],
+    mustKeep: ["666-12-3456", "is just an internal id"],
+  },
+  {
+    id: "mixed-multi",
+    about: "Several structured detectors in one string (recall + ordering)",
+    text: "Email jane.doe@example.com or call 415-555-0132 for Ada Lovelace",
+    mustRedact: ["jane.doe@example.com", "415-555-0132"],
+    mustKeep: ["Email", "or call", "for", "Ada Lovelace"],
+  },
+  {
+    id: "names-not-redacted",
+    about: "Personal names, orgs, and places are NOT redacted (names layer dropped)",
+    text: "Met with Ada Lovelace from Contoso in Seattle to review the plan",
+    mustRedact: [],
+    mustKeep: ["Ada Lovelace", "Contoso", "Seattle", "Met with", "to review the plan"],
+  },
+  {
+    id: "clean-prose",
+    about: "Ordinary prose — no findings (precision)",
+    text: "Opened the quarterly planning doc and reviewed the roadmap for Q3.",
+    mustRedact: [],
+    mustKeep: ["Opened the quarterly planning doc and reviewed the roadmap for Q3."],
+  },
+  {
+    id: "clean-url-and-hash",
+    about: "URL, commit hash, and a bare number are not secrets (precision)",
+    text: "Visited https://github.com/microsoft/skill-recorder at 9c1e6f2a4b7d8e0f1a2b3c4d5e6f7a8b9c0d1e2f build 1234567890",
+    mustRedact: [],
+    mustKeep: [
+      "https://github.com/microsoft/skill-recorder",
+      "9c1e6f2a4b7d8e0f1a2b3c4d5e6f7a8b9c0d1e2f",
+      "build 1234567890",
+    ],
+  },
+];

--- a/evals/sensitive/fixtures/degrade.ts
+++ b/evals/sensitive/fixtures/degrade.ts
@@ -1,0 +1,67 @@
+// Calibrated degradation for the realistic OCR eval. Reproduces the production
+// capture path instead of adding random noise: a fixture is authored as an SVG at
+// a "native display" width, then downscaled to the ~1108px-wide JPEG that Electron
+// actually stores for a captured frame (lanczos3 + lossy JPEG). Feeding THAT to the
+// real `Ocr.recognize()` — which upscales + normalises internally — exercises the
+// exact chain that silently failed in production (small on-screen text OCR'd to
+// garbage → detectors match nothing → nothing blurred). Rendering clean, large text
+// (as the older ocr-images eval does) never stresses this and passes while the
+// feature is broken.
+//
+// Ground-truth boxes are authored in the SVG's hi-res coordinate space and mapped
+// down to the captured-frame space with `scaleBox`, so they line up with the boxes
+// `Ocr`/`sensitiveFrameBoxes` return (which are in captured-frame pixels).
+
+import type { SharpModule } from "./templates";
+
+/** Width of a stored capture frame in pixels — must match production
+ *  (frames are ~1108px wide; see electron/sensitive/ocr.ts preprocessing note). */
+export const CAPTURE_WIDTH = 1108;
+
+/** JPEG quality Electron stores captured frames at (lossy — part of the degradation
+ *  the eval must reproduce). Kept low enough to be realistic, not artificially clean. */
+export const CAPTURE_JPEG_QUALITY = 75;
+
+/** A ground-truth rectangle in some image's pixel space (half-open on x1/y1). */
+export interface GtRect {
+  x0: number;
+  y0: number;
+  x1: number;
+  y1: number;
+}
+
+export interface DegradedFrame {
+  /** The downscaled, JPEG-compressed capture (what production would store on disk). */
+  jpeg: Buffer;
+  /** Applied hi-res → capture scale factor (CAPTURE_WIDTH / hiResWidth). */
+  scale: number;
+  /** Capture-space dimensions (what the OCR + box mapper see). */
+  width: number;
+  height: number;
+}
+
+/** Render a hi-res SVG string, then downscale + JPEG-compress it exactly the way a
+ *  real captured frame is degraded before it ever reaches OCR. */
+export async function renderDegradedFrame(
+  sharp: SharpModule,
+  svg: string,
+  hiResWidth: number,
+): Promise<DegradedFrame> {
+  const scale = CAPTURE_WIDTH / hiResWidth;
+  const jpeg = await sharp(Buffer.from(svg))
+    .resize({ width: CAPTURE_WIDTH, kernel: sharp.kernel.lanczos3 })
+    .jpeg({ quality: CAPTURE_JPEG_QUALITY })
+    .toBuffer();
+  const meta = await sharp(jpeg).metadata();
+  return { jpeg, scale, width: meta.width ?? CAPTURE_WIDTH, height: meta.height ?? 0 };
+}
+
+/** Map a ground-truth rect from hi-res template space into capture-frame space. */
+export function scaleBox(rect: GtRect, scale: number): GtRect {
+  return {
+    x0: Math.round(rect.x0 * scale),
+    y0: Math.round(rect.y0 * scale),
+    x1: Math.round(rect.x1 * scale),
+    y1: Math.round(rect.y1 * scale),
+  };
+}

--- a/evals/sensitive/fixtures/templates.ts
+++ b/evals/sensitive/fixtures/templates.ts
@@ -1,0 +1,311 @@
+// Realistic fixtures for the degraded-frame OCR eval. Each fixture is authored as
+// an SVG that mimics a real app surface (a spreadsheet with tinted cells, a dark
+// terminal, a billing form, a code editor) at a "native display" width, with small
+// UI-sized fonts — NOT the clean, oversized black-on-white text the older
+// ocr-images eval renders. The SVG is rendered then downscaled to a ~1108px capture
+// (see degrade.ts) before OCR, so the eval stresses exactly what broke in
+// production: small on-screen text going to OCR garbage.
+//
+// Ground truth is derived from the layout geometry itself (the rect we allocate for
+// each value), so it can never drift from what's drawn — no hand-maintained label
+// file. Every sensitive region carries an `entityType` for per-type recall, and may
+// carry an `xfail` reason for a known, accepted OCR gap.
+
+import type { GtRect } from "./degrade";
+
+export type SharpModule = typeof import("sharp");
+
+/** Entity taxonomy mirrored from common/sensitive.ts SensitiveCategory, used to
+ *  break recall down per detail type. */
+export type EntityType =
+  | "ssn"
+  | "credit-card"
+  | "phone"
+  | "email"
+  | "api-key"
+  | "jwt"
+  | "private-key"
+  | "password";
+
+export interface FixtureRegion {
+  /** The literal on-screen text (for reporting + as a `knownValue` seed if needed). */
+  text: string;
+  /** Ground-truth rectangle in the fixture's hi-res coordinate space. */
+  rect: GtRect;
+  /** True when this region MUST be covered by a blur box before the frame ships. */
+  sensitive: boolean;
+  /** Detail type — required for sensitive regions (drives per-type recall). */
+  entityType?: EntityType;
+  /** When set, this sensitive region is a KNOWN OCR gap: a miss is reported XFAIL
+   *  (not a hard failure) and an unexpected catch is reported XPASS. */
+  xfail?: string;
+}
+
+export interface RealisticFixture {
+  id: string;
+  about: string;
+  hiResWidth: number;
+  hiResHeight: number;
+  svg: string;
+  regions: FixtureRegion[];
+  /** Values already known from the session's text channel (cross-feed blur). */
+  knownValues?: string[];
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+const SANS = "Arial, 'Helvetica Neue', Helvetica, sans-serif";
+const MONO = "'DejaVu Sans Mono', 'Liberation Mono', 'Courier New', monospace";
+
+interface TextOpts {
+  size: number;
+  fill?: string;
+  family?: string;
+  weight?: number | "bold" | "normal";
+}
+interface RectOpts {
+  fill?: string;
+  stroke?: string;
+  strokeWidth?: number;
+}
+
+/** Tiny imperative SVG builder that keeps drawn geometry and ground-truth regions
+ *  in lock-step. Text is placed by its cell so a value's ground-truth rect is the
+ *  cell we drew it in (robust to per-platform font-metric variance). */
+class Canvas {
+  private readonly parts: string[] = [];
+  readonly regions: FixtureRegion[] = [];
+
+  constructor(
+    readonly width: number,
+    readonly height: number,
+    background: string,
+  ) {
+    this.parts.push(`<rect width="${width}" height="${height}" fill="${background}"/>`);
+  }
+
+  rect(x: number, y: number, w: number, h: number, opts: RectOpts = {}): void {
+    const fill = opts.fill ?? "none";
+    const stroke = opts.stroke ? ` stroke="${opts.stroke}" stroke-width="${opts.strokeWidth ?? 1}"` : "";
+    this.parts.push(`<rect x="${x}" y="${y}" width="${w}" height="${h}" fill="${fill}"${stroke}/>`);
+  }
+
+  /** Draw text with its LEFT edge at x and BASELINE at y. */
+  text(x: number, y: number, s: string, opts: TextOpts): void {
+    const family = opts.family ?? SANS;
+    const weight = opts.weight ? ` font-weight="${opts.weight}"` : "";
+    this.parts.push(
+      `<text x="${x}" y="${y}" font-family="${family}" font-size="${opts.size}" fill="${opts.fill ?? "#111"}"${weight}>${escapeXml(s)}</text>`,
+    );
+  }
+
+  /** Draw a value inside a cell [cx,cy,cw,ch] and record its ground-truth rect as
+   *  that cell (optionally sensitive). Text is vertically centered on the cell. */
+  cell(
+    cx: number,
+    cy: number,
+    cw: number,
+    ch: number,
+    value: string,
+    text: TextOpts,
+    region?: Omit<FixtureRegion, "rect" | "text">,
+  ): void {
+    const padX = Math.round(ch * 0.22);
+    const baseline = cy + Math.round(ch * 0.5 + text.size * 0.35);
+    this.text(cx + padX, baseline, value, text);
+    if (region) {
+      this.regions.push({ text: value, rect: { x0: cx, y0: cy, x1: cx + cw, y1: cy + ch }, ...region });
+    }
+  }
+
+  svg(): string {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="${this.width}" height="${this.height}">${this.parts.join("")}</svg>`;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Fixture: payroll spreadsheet — SSNs + phones in a tinted grid.             */
+/* -------------------------------------------------------------------------- */
+
+function spreadsheetPayroll(): RealisticFixture {
+  const W = 1920;
+  const rowH = 58;
+  const top = 150;
+  const cols = [
+    { key: "name", x: 40, w: 460, label: "Employee" },
+    { key: "ssn", x: 520, w: 420, label: "SSN" },
+    { key: "phone", x: 960, w: 520, label: "Phone" },
+  ];
+  const rows: Array<{ name: string; ssn: string; phone: string }> = [
+    { name: "Ava Chen", ssn: "123-45-6789", phone: "(415) 555-0132" },
+    { name: "Liam Ortiz", ssn: "234-56-7890", phone: "(212) 555-0147" },
+    { name: "Noah Kim", ssn: "345-67-8901", phone: "(650) 555-0188" },
+    { name: "Mia Patel", ssn: "456-78-9012", phone: "(312) 555-0164" },
+    { name: "Emma Ruiz", ssn: "567-89-0123", phone: "(646) 555-0175" },
+  ];
+  const H = top + rows.length * rowH + 40;
+  const c = new Canvas(W, H, "#ffffff");
+  c.text(40, 70, "Q3 Payroll — Confidential", { size: 34, weight: "bold" });
+
+  // Header row (tinted, like a real sheet).
+  c.rect(40, top - rowH, 1440, rowH, { fill: "#e8eef5", stroke: "#c3ccd6" });
+  for (const col of cols) {
+    c.rect(col.x, top - rowH, col.w, rowH, { stroke: "#c3ccd6" });
+    c.text(col.x + 14, top - rowH + Math.round(rowH * 0.62), col.label, { size: 24, fill: "#444", weight: "bold" });
+  }
+
+  rows.forEach((r, i) => {
+    const y = top + i * rowH;
+    const band = i % 2 === 0 ? "#ffffff" : "#f5f8fb"; // alternating rows
+    for (const col of cols) c.rect(col.x, y, col.w, rowH, { fill: band, stroke: "#dfe5ec" });
+    c.cell(cols[0].x, y, cols[0].w, rowH, r.name, { size: 24 }); // clean name
+    c.regions.push({ text: r.name, rect: { x0: cols[0].x, y0: y, x1: cols[0].x + cols[0].w, y1: y + rowH }, sensitive: false });
+    c.cell(cols[1].x, y, cols[1].w, rowH, r.ssn, { size: 24 }, { sensitive: true, entityType: "ssn" });
+    c.cell(cols[2].x, y, cols[2].w, rowH, r.phone, { size: 24 }, { sensitive: true, entityType: "phone" });
+  });
+
+  return { id: "spreadsheet-payroll", about: "Payroll grid: SSNs + phones in small tinted cells", hiResWidth: W, hiResHeight: H, svg: c.svg(), regions: c.regions };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Fixture: billing form — email + Visa + Amex (Amex is a known OCR gap).      */
+/* -------------------------------------------------------------------------- */
+
+function billingForm(): RealisticFixture {
+  const W = 1680;
+  const c = new Canvas(W, 620, "#f2f4f7");
+  c.rect(120, 60, 1440, 500, { fill: "#ffffff", stroke: "#d7dce3" });
+  c.text(160, 130, "Billing details", { size: 30, weight: "bold" });
+
+  const fieldX = 160;
+  const inputX = 520;
+  const inputW = 900;
+  const rows: Array<{ label: string; value: string; sensitive?: EntityType; tint?: string; xfail?: string }> = [
+    { label: "Cardholder", value: "Jordan Blake" },
+    { label: "Email", value: "jordan.blake@example.com", sensitive: "email" },
+    { label: "Card (Visa)", value: "4111 1111 1111 1111", sensitive: "credit-card" },
+    {
+      label: "Card (Amex)",
+      value: "3782 822463 10005",
+      sensitive: "credit-card",
+      tint: "#fdecea", // red-tinted highlighted cell — the documented hard case
+      xfail: "Amex in a red-tinted cell: global-threshold OCR garbles the digits (known gap)",
+    },
+  ];
+  const startY = 190;
+  const rowH = 78;
+  rows.forEach((r, i) => {
+    const y = startY + i * rowH;
+    c.text(fieldX, y + 44, r.label, { size: 24, fill: "#555" });
+    c.rect(inputX, y + 12, inputW, 52, { fill: r.tint ?? "#fbfcfd", stroke: "#c9d0d8" });
+    if (r.sensitive) {
+      c.cell(inputX, y + 12, inputW, 52, r.value, { size: 24 }, { sensitive: true, entityType: r.sensitive, xfail: r.xfail });
+    } else {
+      c.cell(inputX, y + 12, inputW, 52, r.value, { size: 24 });
+      c.regions.push({ text: r.value, rect: { x0: inputX, y0: y + 12, x1: inputX + inputW, y1: y + 64 }, sensitive: false });
+    }
+  });
+  c.rect(inputX, startY + rows.length * rowH + 10, 200, 52, { fill: "#2d6cdf" });
+  c.text(inputX + 46, startY + rows.length * rowH + 44, "Save", { size: 24, fill: "#ffffff", weight: "bold" });
+
+  return { id: "billing-form", about: "Payment form: email + Visa + Amex (Amex tinted-cell = xfail)", hiResWidth: W, hiResHeight: 620, svg: c.svg(), regions: c.regions };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Fixture: terminal — GitHub token + AWS key amid ordinary logs.             */
+/* -------------------------------------------------------------------------- */
+
+function terminalSecrets(): RealisticFixture {
+  const W = 1760;
+  const lineH = 46;
+  const top = 60;
+  const lines: Array<{ pre: string; secret?: { value: string; entityType: EntityType } }> = [
+    { pre: "$ ./deploy.sh --env production" },
+    { pre: "[info] authenticating to registry" },
+    { pre: "export GITHUB_TOKEN=", secret: { value: "ghp_1a2B3c4D5e6F7g8H9i0J1k2L3m4N5o6P7q8R", entityType: "api-key" } },
+    { pre: "[info] uploading build artifacts" },
+    { pre: "AWS_ACCESS_KEY_ID=", secret: { value: "AKIA5XYQ7WZ3PLMN8RTV", entityType: "api-key" } },
+    { pre: "[info] deployment complete in 42s" },
+  ];
+  const H = top + lines.length * lineH + 30;
+  const c = new Canvas(W, H, "#1e1e1e");
+  lines.forEach((ln, i) => {
+    const y = top + i * lineH;
+    const baseline = y + 30;
+    c.text(30, baseline, ln.pre, { size: 24, family: MONO, fill: "#d6d6d6" });
+    if (ln.secret) {
+      // Monospace: advance width ≈ 0.6em per char, so the secret starts right after
+      // the prefix. Its ground-truth rect is that trailing span of the line.
+      const startX = 30 + Math.round(ln.pre.length * 24 * 0.6);
+      const secretW = Math.round(ln.secret.value.length * 24 * 0.6) + 20;
+      c.text(startX, baseline, ln.secret.value, { size: 24, family: MONO, fill: "#d6d6d6" });
+      // These high-entropy secrets are now caught reading-independently: OCR
+      // garbles the exact glyphs (and may split the token across a space), but the
+      // structural detector (frame-heuristics.ts) blurs them by shape — a long,
+      // high-entropy, mixed character-class run (plus credential-assignment
+      // context), with no vendor/prefix list. So they're expected-detect, not a gap.
+      c.regions.push({ text: ln.secret.value, rect: { x0: startX - 6, y0: y + 4, x1: startX + secretW, y1: y + lineH }, sensitive: true, entityType: ln.secret.entityType });
+    } else {
+      c.regions.push({ text: ln.pre, rect: { x0: 24, y0: y + 4, x1: 30 + Math.round(ln.pre.length * 24 * 0.6), y1: y + lineH }, sensitive: false });
+    }
+  });
+  return { id: "terminal-secrets", about: "Dark terminal: GitHub token + AWS key amid logs", hiResWidth: W, hiResHeight: H, svg: c.svg(), regions: c.regions };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Fixture: code editor — Stripe key + JWT in a config file.                   */
+/* -------------------------------------------------------------------------- */
+
+function codeConfig(): RealisticFixture {
+  const W = 1760;
+  const lineH = 46;
+  const top = 60;
+  const gutter = 90;
+  const jwt =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NSIsIm5hbWUiOiJKb2UifQ.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U";
+  const lines: Array<{ text: string; secret?: { value: string; entityType: EntityType } }> = [
+    { text: "# config/production.yaml" },
+    { text: "service: recorder-api" },
+    { text: "stripe_secret_key: ", secret: { value: "sk_live_" + "4eC39HqLyjWDarjtT1zdp7dcABCDEFGH1234", entityType: "api-key" } },
+    { text: "retries: 3" },
+    { text: "session_jwt: ", secret: { value: jwt, entityType: "jwt" } },
+    { text: "log_level: info" },
+  ];
+  const H = top + lines.length * lineH + 30;
+  const c = new Canvas(W, H, "#1e1e2e");
+  c.rect(0, 0, gutter, H, { fill: "#181825" });
+  lines.forEach((ln, i) => {
+    const y = top + i * lineH;
+    const baseline = y + 30;
+    c.text(24, baseline, String(i + 1), { size: 22, family: MONO, fill: "#6c7086" });
+    const keyColor = ln.text.startsWith("#") ? "#7f849c" : "#a6adc8";
+    c.text(gutter + 20, baseline, ln.text, { size: 24, family: MONO, fill: keyColor });
+    if (ln.secret) {
+      const startX = gutter + 20 + Math.round(ln.text.length * 24 * 0.6);
+      const secretW = Math.round(ln.secret.value.length * 24 * 0.6) + 20;
+      c.text(startX, baseline, ln.secret.value, { size: 24, family: MONO, fill: "#a6e3a1" });
+      // Caught reading-independently by the structural detector (see the terminal
+      // fixture): a Stripe key / JWT is high-entropy, so even when OCR misreads a
+      // glyph or injects a space it's blurred by shape (length + character-class
+      // entropy + credential-assignment context, no prefix list). Expected-detect.
+      c.regions.push({ text: ln.secret.value, rect: { x0: startX - 6, y0: y + 4, x1: startX + secretW, y1: y + lineH }, sensitive: true, entityType: ln.secret.entityType });
+    } else {
+      c.regions.push({ text: ln.text, rect: { x0: gutter + 14, y0: y + 4, x1: gutter + 20 + Math.round(ln.text.length * 24 * 0.6), y1: y + lineH }, sensitive: false });
+    }
+  });
+  return { id: "code-config", about: "Code editor: Stripe key + JWT in a YAML config", hiResWidth: W, hiResHeight: H, svg: c.svg(), regions: c.regions };
+}
+
+export const realisticFixtures: RealisticFixture[] = [
+  spreadsheetPayroll(),
+  billingForm(),
+  terminalSecrets(),
+  codeConfig(),
+];

--- a/evals/sensitive/frames.ts
+++ b/evals/sensitive/frames.ts
@@ -1,0 +1,74 @@
+// Fixed corpus for the frame OCR + blur evals (the opt-in Advanced-protection
+// image channel). Real frames are OCR'd on-device with tesseract; here we supply
+// the recognized words + their pixel boxes directly, so the box-mapping logic —
+// join words → run the shared detectors → paint every word whose char span
+// overlaps a match — is exercised deterministically without tesseract or sharp.
+//
+// Each word carries `sensitive: true` when its box MUST be blurred. Words are laid
+// out left-to-right on one row with wide gaps, so a padded box only ever overlaps
+// its own word (no ambiguous neighbor overlap during scoring).
+
+export interface FrameWord {
+  text: string;
+  /** True when this word's box must be covered before the frame is sent. */
+  sensitive?: boolean;
+}
+
+export interface FrameCase {
+  id: string;
+  about: string;
+  words: FrameWord[];
+  /** Values already detected in the session's text (cross-feed blur). */
+  knownValues?: string[];
+}
+
+export const frameCorpus: FrameCase[] = [
+  {
+    id: "frame-github-token",
+    about: "A GitHub token visible on screen (secretlint over OCR text)",
+    words: [
+      { text: "run" },
+      { text: "ghp_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8", sensitive: true },
+      { text: "now" },
+    ],
+  },
+  {
+    id: "frame-email",
+    about: "An email address on screen (structured PII over OCR text)",
+    words: [
+      { text: "contact" },
+      { text: "jane.doe@example.com", sensitive: true },
+      { text: "today" },
+    ],
+  },
+  {
+    id: "frame-card-split",
+    about: "A card number OCR'd as four separate words — all four boxes blur",
+    words: [
+      { text: "card" },
+      { text: "4111", sensitive: true },
+      { text: "1111", sensitive: true },
+      { text: "1111", sensitive: true },
+      { text: "1111", sensitive: true },
+      { text: "ok" },
+    ],
+  },
+  {
+    id: "frame-known-value-cross-feed",
+    about: "A phone number flagged in the session text, blurred on screen via cross-feed",
+    words: [
+      { text: "call" },
+      { text: "+44", sensitive: true },
+      { text: "20", sensitive: true },
+      { text: "7946", sensitive: true },
+      { text: "0958", sensitive: true },
+      { text: "now" },
+    ],
+    knownValues: ["+44 20 7946 0958"],
+  },
+  {
+    id: "frame-clean",
+    about: "Ordinary on-screen text — nothing blurred (precision)",
+    words: [{ text: "Opened" }, { text: "the" }, { text: "roadmap" }, { text: "doc" }],
+  },
+];

--- a/evals/sensitive/ocr-images.ts
+++ b/evals/sensitive/ocr-images.ts
@@ -1,0 +1,263 @@
+// OPT-IN real-image OCR eval (NOT part of the hermetic `eval:sensitive` run).
+//
+// The default sensitive frame eval feeds SYNTHETIC OCR words to the box mapper, so
+// it can't catch the real leak vector: Tesseract misreading on-screen text badly
+// enough that a secret/PII value is never detected (and the frame ships unblurred).
+// This harness closes that gap end-to-end: it renders text to actual JPEGs, runs
+// the REAL `Ocr` engine + the shared detectors via `sensitiveFrameBoxes`, and checks
+// that every sensitive line gets a blur box while clean lines are left alone.
+//
+// It is non-hermetic (needs the tesseract WASM core, `sharp` with system fonts, and
+// a one-time traineddata download per language), so it lives behind its own script
+// and SELF-SKIPS (exit 0) when the environment can't support it rather than failing.
+//
+// Run:
+//   npm run eval:sensitive:ocr            # renders text → JPEG, real Tesseract (English)
+//   npm run eval:sensitive:ocr -- --keep  # print each rendered case's OCR text
+
+import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
+import { mkdir, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { Ocr, tessdataFileName, type OcrWord } from "../../electron/sensitive/ocr";
+import { sensitiveFrameBoxes, type FrameBox } from "../../electron/sensitive/frame-redact";
+
+const require = createRequire(import.meta.url);
+const TESSDATA_BASE = "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/65727574dfcd264acbb0c3e07860e4e9e9b22185";
+const CACHE_DIR = path.join(process.cwd(), "evals", ".cache", "tessdata");
+
+// Layout: one row per line, generous line height, so a box's vertical position
+// alone tells us which line it covers (robust to Tesseract's horizontal jitter).
+const WIDTH = 1000;
+const PAD = 34;
+const LINE_H = 74;
+const FONT = 34;
+
+interface Row {
+  text: string;
+  /** Sensitive rows MUST get a blur box; clean rows must NOT. */
+  sensitive: boolean;
+}
+
+interface OcrImageCase {
+  id: string;
+  about: string;
+  rows: Row[];
+  /** Session values known from clean text (cross-feed blur). */
+  knownValues?: string[];
+}
+
+const cases: OcrImageCase[] = [
+  {
+    id: "eng-secret-token",
+    about: "GitHub token on screen amid ordinary log lines (English)",
+    rows: [
+      { text: "Deployment log for release build", sensitive: false },
+      { text: "token ghp_abcdefghij0123456789ABCDEFGHIJKLMNPQ", sensitive: true },
+      { text: "Status: completed successfully", sensitive: false },
+    ],
+  },
+  {
+    id: "eng-card-and-email",
+    about: "Credit card + email on screen (English)",
+    rows: [
+      { text: "Customer billing record", sensitive: false },
+      { text: "Card 4111 1111 1111 1111 exp 09 27", sensitive: true },
+      { text: "Contact jordan.blake@example.com", sensitive: true },
+      { text: "Notes: follow up next week", sensitive: false },
+    ],
+  },
+  {
+    id: "eng-known-crossfeed",
+    about: "Codeword known from clean text is blurred wherever it appears (English)",
+    knownValues: ["APERTURE"],
+    rows: [
+      { text: "Project APERTURE kickoff", sensitive: true },
+      { text: "Public roadmap discussion", sensitive: false },
+    ],
+  },
+  {
+    // The eng-only product decision in action: a Japanese screen with English-only
+    // traineddata loaded. The Latin email is ASCII, so eng OCR still reads (and
+    // blurs) it even though the surrounding Japanese lines come back as garbage.
+    id: "eng-only-email-amid-japanese",
+    about: "Latin email amid Japanese text, read with ENGLISH-ONLY traineddata",
+    rows: [
+      { text: "ログイン情報の確認", sensitive: false },
+      { text: "メール: taro.yamada@example.co.jp", sensitive: true },
+      { text: "処理が完了しました", sensitive: false },
+    ],
+  },
+];
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+interface Rendered {
+  buffer: Buffer;
+  width: number;
+  height: number;
+  bands: Array<{ top: number; bottom: number }>;
+}
+
+type SharpModule = typeof import("sharp");
+
+/** Render rows to a JPEG (black text on white), one row per fixed-height band. */
+async function renderRows(sharp: SharpModule, rows: Row[]): Promise<Rendered> {
+  const height = PAD * 2 + rows.length * LINE_H;
+  const bands = rows.map((_, i) => ({ top: PAD + i * LINE_H, bottom: PAD + (i + 1) * LINE_H }));
+  const texts = rows
+    .map((row, i) => {
+      const y = PAD + i * LINE_H + Math.round((LINE_H + FONT) / 2) - 6;
+      return `<text x="${PAD}" y="${y}" font-family="sans-serif" font-size="${FONT}" fill="#000">${escapeXml(row.text)}</text>`;
+    })
+    .join("");
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${height}"><rect width="${WIDTH}" height="${height}" fill="#fff"/>${texts}</svg>`;
+  const buffer = await sharp(Buffer.from(svg)).jpeg({ quality: 92 }).toBuffer();
+  return { buffer, width: WIDTH, height, bands };
+}
+
+function boxOverlapsBand(box: FrameBox, band: { top: number; bottom: number }): boolean {
+  return box.top < band.bottom && band.top < box.top + box.height;
+}
+
+async function ensureTraineddata(code: string): Promise<boolean> {
+  const dest = path.join(CACHE_DIR, tessdataFileName(code));
+  if (existsSync(dest)) return true;
+  await mkdir(CACHE_DIR, { recursive: true });
+  try {
+    const res = await fetch(`${TESSDATA_BASE}/${tessdataFileName(code)}`);
+    if (!res.ok) return false;
+    const buf = Buffer.from(await res.arrayBuffer());
+    const tmp = `${dest}.tmp.${process.pid}`;
+    await writeFile(tmp, buf);
+    await rename(tmp, dest);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+interface CaseResult {
+  id: string;
+  about: string;
+  status: "pass" | "fail" | "skip";
+  detail: string;
+  ocrText?: string;
+}
+
+const ocrPools = new Map<string, Ocr>();
+
+function pool(): Ocr {
+  let p = ocrPools.get("eng");
+  if (!p) {
+    p = new Ocr({ langPath: CACHE_DIR, poolSize: 1 });
+    ocrPools.set("eng", p);
+  }
+  return p;
+}
+
+async function scoreCase(sharp: SharpModule, c: OcrImageCase, keep: boolean): Promise<CaseResult> {
+  if (!(await ensureTraineddata("eng"))) {
+    return { id: c.id, about: c.about, status: "skip", detail: `no traineddata for "eng" (offline?)` };
+  }
+
+  let words: OcrWord[];
+  const rendered = await renderRows(sharp, c.rows);
+  try {
+    words = await pool().recognize(rendered.buffer);
+  } catch (err) {
+    return { id: c.id, about: c.about, status: "skip", detail: `OCR engine unavailable: ${err instanceof Error ? err.message : err}` };
+  }
+  const ocrText = words.map((w) => w.text).join(" ");
+
+  const boxes = await sensitiveFrameBoxes(words, {
+    width: rendered.width,
+    height: rendered.height,
+    knownValues: c.knownValues,
+  });
+
+  const problems: string[] = [];
+  rendered.bands.forEach((band, i) => {
+    const covered = boxes.some((b) => boxOverlapsBand(b, band));
+    const row = c.rows[i];
+    if (row.sensitive && !covered) problems.push(`leaked (no blur): "${row.text}"`);
+    if (!row.sensitive && covered) problems.push(`over-blur (clean line covered): "${row.text}"`);
+  });
+
+  const result: CaseResult = {
+    id: c.id,
+    about: c.about,
+    status: problems.length ? "fail" : "pass",
+    detail: problems.length ? problems.join("; ") : `${boxes.length} box(es) over ${c.rows.filter((r) => r.sensitive).length} sensitive line(s)`,
+  };
+  if (keep) result.ocrText = ocrText;
+  return result;
+}
+
+/** Probe render+OCR of a known string; returns false if the environment can't OCR. */
+async function environmentUsable(sharp: SharpModule): Promise<boolean> {
+  if (!(await ensureTraineddata("eng"))) return false;
+  try {
+    const probe = await renderRows(sharp, [{ text: "Sensitive check 12345", sensitive: false }]);
+    const words = await pool().recognize(probe.buffer);
+    const text = words.map((w) => w.text).join(" ");
+    return /12345/.test(text);
+  } catch {
+    return false;
+  }
+}
+
+function loadSharp(): SharpModule | null {
+  try {
+    return require("sharp") as SharpModule;
+  } catch {
+    return null;
+  }
+}
+
+async function main(): Promise<void> {
+  const keep = process.argv.includes("--keep");
+  console.error(`\nSkill Recorder — real-image OCR redaction eval (opt-in, non-hermetic)`);
+
+  const sharp = loadSharp();
+  if (!sharp) {
+    console.error("  SKIP: sharp is not available; cannot render eval images.\n");
+    process.exit(0);
+  }
+  if (!(await environmentUsable(sharp))) {
+    console.error("  SKIP: OCR could not read a probe image (missing fonts, WASM core, or traineddata download).\n");
+    await Promise.all([...ocrPools.values()].map((p) => p.terminate().catch(() => {})));
+    process.exit(0);
+  }
+
+  const results: CaseResult[] = [];
+  for (const c of cases) results.push(await scoreCase(sharp, c, keep));
+  await Promise.all([...ocrPools.values()].map((p) => p.terminate().catch(() => {})));
+
+  console.error("─".repeat(64));
+  for (const r of results) {
+    const tag = r.status === "pass" ? "PASS" : r.status === "skip" ? "SKIP" : "FAIL";
+    console.error(`  ${tag}  ${r.id} — ${r.about}`);
+    console.error(`        ${r.detail}`);
+    if (r.ocrText) console.error(`        OCR: ${r.ocrText}`);
+  }
+
+  const failed = results.filter((r) => r.status === "fail");
+  const passed = results.filter((r) => r.status === "pass").length;
+  const skipped = results.filter((r) => r.status === "skip").length;
+  console.error(`\n  ${passed} passed · ${failed.length} failed · ${skipped} skipped (of ${results.length})\n`);
+  process.exit(failed.length ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error("OCR image harness crashed:", err);
+  process.exit(3);
+});

--- a/evals/sensitive/ocr-realistic.ts
+++ b/evals/sensitive/ocr-realistic.ts
@@ -1,0 +1,206 @@
+// OPT-IN degraded-frame OCR redaction eval (NOT part of the hermetic run).
+//
+// This is the eval the older ocr-images harness should have been. It renders
+// realistic app surfaces (spreadsheet, billing form, terminal, code editor) and
+// pushes each through the REAL capture degradation — downscale to a ~1108px JPEG
+// (see fixtures/degrade.ts) — before running the REAL `Ocr` engine + the shared
+// `sensitiveFrameBoxes`. It then scores whether every sensitive region got a blur
+// box (region-overlap recall, per entity type, F2, over-blur), the way a
+// locate-and-blur safety net should be measured. Known OCR gaps are marked `xfail`.
+//
+// Like ocr-images it is non-hermetic (needs the tesseract WASM core, `sharp` with
+// system fonts, and a one-time traineddata download) and SELF-SKIPS (exit 0) when
+// the environment can't support it, rather than failing.
+//
+// Run:
+//   npm run eval:sensitive:realistic            # render → degrade → real Tesseract
+//   npm run eval:sensitive:realistic -- --keep  # also print OCR text + box counts
+//   npm run eval:sensitive:realistic -- --write  # dump degraded JPEGs to evals/.cache
+//   npm run eval:sensitive:realistic -- --only=billing-form
+
+import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
+import { mkdir, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { Ocr, tessdataFileName } from "../../electron/sensitive/ocr";
+import { sensitiveFrameBoxes } from "../../electron/sensitive/frame-redact";
+import { renderDegradedFrame } from "./fixtures/degrade";
+import { realisticFixtures, type RealisticFixture, type SharpModule } from "./fixtures/templates";
+import { aggregate, scoreFixture, type FixtureScore } from "./realistic-score";
+
+const require = createRequire(import.meta.url);
+const TESSDATA_BASE = "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/65727574dfcd264acbb0c3e07860e4e9e9b22185";
+const CACHE_DIR = path.join(process.cwd(), "evals", ".cache", "tessdata");
+const DUMP_DIR = path.join(process.cwd(), "evals", ".cache", "realistic");
+
+// Gates (see the research synthesis): recall is the privacy-critical number.
+const RECALL_GATE = 0.95;       // hard: below this, sensitive detail is leaking
+const PER_TYPE_GATE = 0.9;      // hard, for types with enough cases to be meaningful
+const PER_TYPE_MIN_CASES = 5;
+const OVER_BLUR_WARN = 0.1;     // soft: warn if we blur too much clean content
+const F2_TARGET = 0.85;         // logged
+
+interface Flags {
+  keep: boolean;
+  write: boolean;
+  only: Set<string> | null;
+}
+
+function parseFlags(argv: string[]): Flags {
+  const flags: Flags = { keep: false, write: false, only: null };
+  for (const arg of argv) {
+    if (arg === "--keep") flags.keep = true;
+    else if (arg === "--write") flags.write = true;
+    else if (arg.startsWith("--only=")) flags.only = new Set(arg.slice(7).split(",").map((s) => s.trim()).filter(Boolean));
+  }
+  return flags;
+}
+
+function loadSharp(): SharpModule | null {
+  try {
+    return require("sharp") as SharpModule;
+  } catch {
+    return null;
+  }
+}
+
+async function ensureTraineddata(code: string): Promise<boolean> {
+  const dest = path.join(CACHE_DIR, tessdataFileName(code));
+  if (existsSync(dest)) return true;
+  await mkdir(CACHE_DIR, { recursive: true });
+  try {
+    const res = await fetch(`${TESSDATA_BASE}/${tessdataFileName(code)}`);
+    if (!res.ok) return false;
+    const tmp = `${dest}.tmp.${process.pid}`;
+    await writeFile(tmp, Buffer.from(await res.arrayBuffer()));
+    await rename(tmp, dest);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+let ocrPool: Ocr | null = null;
+function pool(): Ocr {
+  return (ocrPool ??= new Ocr({ langPath: CACHE_DIR, poolSize: 2 }));
+}
+
+/** Probe render+OCR of a known string; false if the environment can't OCR. */
+async function environmentUsable(sharp: SharpModule): Promise<boolean> {
+  if (!(await ensureTraineddata("eng"))) return false;
+  try {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="600" height="120"><rect width="600" height="120" fill="#fff"/><text x="20" y="70" font-family="sans-serif" font-size="40" fill="#000">Probe 12345</text></svg>`;
+    const buf = await sharp(Buffer.from(svg)).jpeg({ quality: 90 }).toBuffer();
+    const words = await pool().recognize(buf);
+    return /12345/.test(words.map((w) => w.text).join(" "));
+  } catch {
+    return false;
+  }
+}
+
+interface EvalResult {
+  score: FixtureScore;
+  ocrText?: string;
+}
+
+async function runFixture(sharp: SharpModule, fixture: RealisticFixture, keep: boolean, write: boolean): Promise<EvalResult> {
+  const frame = await renderDegradedFrame(sharp, fixture.svg, fixture.hiResWidth);
+  if (write) {
+    await mkdir(DUMP_DIR, { recursive: true });
+    await writeFile(path.join(DUMP_DIR, `${fixture.id}.jpg`), frame.jpeg);
+  }
+  const words = await pool().recognize(frame.jpeg);
+  const boxes = await sensitiveFrameBoxes(words, {
+    width: frame.width,
+    height: frame.height,
+    knownValues: fixture.knownValues,
+  });
+  const score = scoreFixture(fixture.id, fixture.about, fixture.regions, boxes, frame.scale);
+  return { score, ocrText: keep ? words.map((w) => w.text).join(" ") : undefined };
+}
+
+const bar = "─".repeat(72);
+const pct = (n: number, d: number): string => (d ? `${(100 * (n / d)).toFixed(0)}%` : "  —");
+
+async function main(): Promise<void> {
+  const flags = parseFlags(process.argv.slice(2));
+  console.error(`\nSkill Recorder — realistic degraded-frame OCR redaction eval (opt-in, non-hermetic)`);
+
+  const sharp = loadSharp();
+  if (!sharp) {
+    console.error("  SKIP: sharp is not available; cannot render eval images.\n");
+    process.exit(0);
+  }
+  if (!(await environmentUsable(sharp))) {
+    console.error("  SKIP: OCR could not read a probe image (missing fonts, WASM core, or traineddata download).\n");
+    await pool().terminate().catch(() => {});
+    process.exit(0);
+  }
+
+  const fixtures = realisticFixtures.filter((f) => !flags.only || flags.only.has(f.id));
+  if (fixtures.length === 0) {
+    console.error("  No fixtures matched", flags.only ? [...flags.only] : "");
+    await pool().terminate().catch(() => {});
+    process.exit(2);
+  }
+
+  const results: EvalResult[] = [];
+  for (const f of fixtures) results.push(await runFixture(sharp, f, flags.keep, flags.write));
+  await pool().terminate().catch(() => {});
+
+  console.error(bar);
+  for (const { score, ocrText } of results) {
+    const leaks = score.leaks.length;
+    const tag = leaks ? "FAIL" : "PASS";
+    console.error(`\n  ${tag}  ${score.id} — ${score.about}`);
+    console.error(`        ${score.boxCount} blur box(es)`);
+    for (const r of score.regions) {
+      if (r.outcome === "fn") console.error(`        ✗ LEAK  [${r.entityType}] ${r.text}`);
+      else if (r.outcome === "over-blur") console.error(`        ~ over-blur (clean): ${r.text}`);
+      else if (r.outcome === "xfail") console.error(`        · xfail  [${r.entityType}] ${r.text} (known gap)`);
+      else if (r.outcome === "xpass") console.error(`        ✓ xpass  [${r.entityType}] ${r.text} (known gap now caught)`);
+    }
+    if (ocrText) console.error(`        OCR: ${ocrText.slice(0, 400)}`);
+  }
+
+  const totals = aggregate(results.map((r) => r.score));
+
+  console.error(`\n${bar}\nSummary`);
+  console.error(`  recall (sensitive regions blurred):  ${totals.tp}/${totals.tp + totals.fn}  ${pct(totals.tp, totals.tp + totals.fn)}`);
+  console.error(`  over-blur (clean regions covered):   ${totals.overBlur}/${totals.cleanTotal}  ${pct(totals.overBlur, totals.cleanTotal)}`);
+  console.error(`  F2 (β=2, recall-weighted):           ${totals.f2.toFixed(3)}`);
+  if (totals.xfail || totals.xpass) console.error(`  known gaps:                          ${totals.xfail} xfail · ${totals.xpass} xpass`);
+  console.error(`\n  per entity type:`);
+  for (const [type, b] of Object.entries(totals.perType).sort()) {
+    const gated = b.total >= PER_TYPE_MIN_CASES ? " (gated)" : "";
+    console.error(`    ${type.padEnd(12)} ${b.covered}/${b.total}  ${pct(b.covered, b.total)}${gated}`);
+  }
+
+  // Gates.
+  const failures: string[] = [];
+  if (totals.recall < RECALL_GATE) failures.push(`overall recall ${pct(totals.tp, totals.tp + totals.fn)} < gate ${RECALL_GATE * 100}%`);
+  for (const [type, b] of Object.entries(totals.perType)) {
+    if (b.total >= PER_TYPE_MIN_CASES && b.covered / b.total < PER_TYPE_GATE) {
+      failures.push(`per-type recall ${type} ${pct(b.covered, b.total)} < gate ${PER_TYPE_GATE * 100}%`);
+    }
+  }
+
+  console.error("");
+  if (totals.overBlurRate > OVER_BLUR_WARN) console.error(`  ⚠ WARN: over-blur rate ${pct(totals.overBlur, totals.cleanTotal)} > ${OVER_BLUR_WARN * 100}%`);
+  if (totals.f2 < F2_TARGET) console.error(`  ⚠ NOTE: F2 ${totals.f2.toFixed(3)} < target ${F2_TARGET}`);
+
+  if (failures.length) {
+    console.error(`\n  ✗ GATE FAILED:`);
+    for (const f of failures) console.error(`      - ${f}`);
+    console.error("");
+    process.exit(1);
+  }
+  console.error(`\n  ✓ all gates passed\n`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("Realistic OCR harness crashed:", err);
+  process.exit(3);
+});

--- a/evals/sensitive/realistic-score.ts
+++ b/evals/sensitive/realistic-score.ts
@@ -1,0 +1,140 @@
+// Metrics for the degraded-frame OCR eval. The right question for a locate-and-blur
+// safety net is NOT "did OCR transcribe the text correctly?" (CER/WER) but "did a
+// blur box actually land over the sensitive region?" — a garbled-but-covered value
+// is still safe, while a perfectly-transcribed-but-uncovered one leaks. So scoring
+// is region-overlap based:
+//   - recall (primary): fraction of sensitive regions covered by some blur box.
+//   - per-entity-type recall: the same, split by detail type, to catch a regression
+//     that only hurts one type (e.g. cards) while overall recall still looks fine.
+//   - over-blur rate: fraction of clean regions a box covered (precision proxy).
+//   - F2 (β=2): recall-weighted harmonic mean, matching Presidio's redaction default.
+// Known, accepted gaps are marked `xfail` on the fixture region: a miss there is
+// reported but does NOT count against the recall gate (an unexpected catch is XPASS).
+
+import type { FrameBox } from "../../electron/sensitive/frame-redact";
+import { scaleBox, type GtRect } from "./fixtures/degrade";
+import type { EntityType, FixtureRegion } from "./fixtures/templates";
+
+/** A clean region counts as over-blurred only when a box covers a meaningful share
+ *  of it — small padding bleed from an adjacent sensitive box shouldn't be a "fail". */
+const OVER_BLUR_MIN_FRACTION = 0.3;
+
+export type RegionOutcome = "tp" | "fn" | "xfail" | "xpass" | "clean-ok" | "over-blur";
+
+export interface ScoredRegion {
+  text: string;
+  entityType?: EntityType;
+  sensitive: boolean;
+  outcome: RegionOutcome;
+}
+
+export interface FixtureScore {
+  id: string;
+  about: string;
+  boxCount: number;
+  regions: ScoredRegion[];
+  /** Leaked sensitive values (FN, non-xfail) — the privacy-critical failures. */
+  leaks: string[];
+}
+
+function boxRect(b: FrameBox): GtRect {
+  return { x0: b.left, y0: b.top, x1: b.left + b.width, y1: b.top + b.height };
+}
+
+function intersectionArea(a: GtRect, b: GtRect): number {
+  const w = Math.min(a.x1, b.x1) - Math.max(a.x0, b.x0);
+  const h = Math.min(a.y1, b.y1) - Math.max(a.y0, b.y0);
+  return w > 0 && h > 0 ? w * h : 0;
+}
+
+function area(r: GtRect): number {
+  return Math.max(0, r.x1 - r.x0) * Math.max(0, r.y1 - r.y0);
+}
+
+/** Score one fixture's regions against the blur boxes the real pipeline produced.
+ *  `regions` are in hi-res template space; `scale` maps them into the capture space
+ *  the boxes live in. */
+export function scoreFixture(
+  id: string,
+  about: string,
+  regions: FixtureRegion[],
+  boxes: FrameBox[],
+  scale: number,
+): FixtureScore {
+  const boxRects = boxes.map(boxRect);
+  const scored: ScoredRegion[] = [];
+  const leaks: string[] = [];
+
+  for (const region of regions) {
+    const rect = scaleBox(region.rect, scale);
+    if (region.sensitive) {
+      const covered = boxRects.some((b) => intersectionArea(b, rect) > 0);
+      let outcome: RegionOutcome;
+      if (region.xfail) outcome = covered ? "xpass" : "xfail";
+      else {
+        outcome = covered ? "tp" : "fn";
+        if (!covered) leaks.push(region.text);
+      }
+      scored.push({ text: region.text, entityType: region.entityType, sensitive: true, outcome });
+    } else {
+      const a = area(rect);
+      const covered = a > 0 && boxRects.some((b) => intersectionArea(b, rect) >= OVER_BLUR_MIN_FRACTION * a);
+      scored.push({ text: region.text, sensitive: false, outcome: covered ? "over-blur" : "clean-ok" });
+    }
+  }
+
+  return { id, about, boxCount: boxes.length, regions: scored, leaks };
+}
+
+export interface TypeTotals {
+  covered: number;
+  total: number;
+}
+
+export interface RealisticTotals {
+  tp: number;
+  fn: number;
+  overBlur: number;
+  cleanTotal: number;
+  xfail: number;
+  xpass: number;
+  perType: Record<string, TypeTotals>;
+  recall: number;
+  overBlurRate: number;
+  precision: number;
+  f2: number;
+}
+
+export function aggregate(scores: FixtureScore[]): RealisticTotals {
+  const t: RealisticTotals = {
+    tp: 0, fn: 0, overBlur: 0, cleanTotal: 0, xfail: 0, xpass: 0,
+    perType: {}, recall: 1, overBlurRate: 0, precision: 1, f2: 1,
+  };
+  for (const s of scores) {
+    for (const r of s.regions) {
+      if (r.sensitive) {
+        if (r.outcome === "xfail") t.xfail += 1;
+        else if (r.outcome === "xpass") t.xpass += 1;
+        else {
+          const type = r.entityType ?? "unknown";
+          const bucket = (t.perType[type] ??= { covered: 0, total: 0 });
+          bucket.total += 1;
+          if (r.outcome === "tp") { t.tp += 1; bucket.covered += 1; } else t.fn += 1;
+        }
+      } else {
+        t.cleanTotal += 1;
+        if (r.outcome === "over-blur") t.overBlur += 1;
+      }
+    }
+  }
+  const sensitive = t.tp + t.fn;
+  t.recall = sensitive ? t.tp / sensitive : 1;
+  t.overBlurRate = t.cleanTotal ? t.overBlur / t.cleanTotal : 0;
+  t.precision = t.tp + t.overBlur ? t.tp / (t.tp + t.overBlur) : 1;
+  t.f2 = t.precision + t.recall ? (5 * t.precision * t.recall) / (4 * t.precision + t.recall) : 0;
+  return t;
+}
+
+export function f2(precision: number, recall: number): number {
+  return precision + recall ? (5 * precision * recall) / (4 * precision + recall) : 0;
+}

--- a/evals/sensitive/run.ts
+++ b/evals/sensitive/run.ts
@@ -1,0 +1,99 @@
+// Sensitive-detail eval harness: runs the real on-device detection + redaction
+// pipeline (secretlint + structured-PII regex) over a fixed corpus and scores
+// recall (every known secret/PII value is masked before it could leave the
+// machine) and precision (ordinary prose is left intact). No model weights, no
+// network, no LLM — fully deterministic.
+//
+// Run:
+//   node --experimental-transform-types --import ./evals/register.mjs evals/sensitive/run.ts [flags]
+// Flags:
+//   --only=slug,slug   run a subset of cases
+//   --verbose          print the redacted output for every case
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import { sensitiveCorpus } from "./corpus";
+import { frameCorpus } from "./frames";
+import { scoreCase, scoreFrameCase, tally, type CaseScore } from "./score";
+
+interface Flags {
+  only: Set<string> | null;
+  verbose: boolean;
+}
+
+function parseFlags(argv: string[]): Flags {
+  const flags: Flags = { only: null, verbose: false };
+  for (const arg of argv) {
+    if (arg.startsWith("--only=")) flags.only = new Set(arg.slice(7).split(",").map((s) => s.trim()).filter(Boolean));
+    else if (arg === "--verbose") flags.verbose = true;
+  }
+  return flags;
+}
+
+const bar = "─".repeat(64);
+
+function report(scores: CaseScore[], verbose: boolean): void {
+  for (const s of scores) {
+    const status = s.pass ? "PASS " : "FAIL ";
+    console.error(`\n${s.pass ? "✓" : "✗"} ${s.id} — ${s.about}`);
+    console.error(`   ${status} ${Math.round(s.score * 100)}% · ${s.matchCount} finding(s)`);
+    for (const check of s.checks) {
+      if (!check.pass) console.error(`     ✗ ${check.name}${check.detail ? ` — ${check.detail}` : ""}`);
+    }
+    if (verbose) console.error(`   → ${s.redacted}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const flags = parseFlags(process.argv.slice(2));
+  const textCases = sensitiveCorpus.filter((c) => !flags.only || flags.only.has(c.id));
+  const frameCases = frameCorpus.filter((c) => !flags.only || flags.only.has(c.id));
+  if (textCases.length + frameCases.length === 0) {
+    console.error("No cases matched", flags.only ? [...flags.only] : "");
+    process.exit(2);
+  }
+
+  console.error(`\nSkill Recorder — sensitive detection + redaction evals`);
+  console.error(`${textCases.length} text case(s) · ${frameCases.length} frame case(s)`);
+
+  console.error(`${bar}\nText channels (secretlint + structured PII → redaction)`);
+  const textScores: CaseScore[] = [];
+  for (const c of textCases) textScores.push(await scoreCase(c));
+  report(textScores, flags.verbose);
+
+  console.error(`\n${bar}\nFrame channel (OCR words → detectors → blur boxes)`);
+  const frameScores: CaseScore[] = [];
+  for (const c of frameCases) frameScores.push(await scoreFrameCase(c));
+  report(frameScores, flags.verbose);
+
+  const scores = [...textScores, ...frameScores];
+  const totals = tally(scores);
+  const pct = (n: number, d: number): string => (d ? `${Math.round((n / d) * 100)}%` : "  — ");
+
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const outFile = path.join(process.cwd(), "evals", "results", `sensitive-${stamp}.json`);
+  mkdirSync(path.dirname(outFile), { recursive: true });
+  writeFileSync(outFile, JSON.stringify({ at: stamp, totals, scores }, null, 2));
+
+  console.error(`\n${bar}\nSummary`);
+  const passed = scores.filter((s) => s.pass).length;
+  for (const s of scores) {
+    console.error(`  ${s.pass ? "PASS " : "FAIL "} ${Math.round(s.score * 100).toString().padStart(3)}%  ${s.id}`);
+  }
+  console.error(
+    `\n  recall (sensitive detail masked/blurred):  ${totals.recallPass}/${totals.recallTotal}  ${pct(totals.recallPass, totals.recallTotal)}`,
+  );
+  console.error(
+    `  precision (ordinary content kept):         ${totals.precisionPass}/${totals.precisionTotal}  ${pct(totals.precisionPass, totals.precisionTotal)}`,
+  );
+  console.error(`\n  ${passed}/${scores.length} cases passed`);
+  console.error(`  results: ${path.relative(process.cwd(), outFile)}\n`);
+
+  process.exit(passed === scores.length ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error("Harness crashed:", err);
+  process.exit(3);
+});

--- a/evals/sensitive/score.ts
+++ b/evals/sensitive/score.ts
@@ -1,0 +1,195 @@
+// Deterministic, LLM-free scoring for the sensitive-detail evals.
+//
+// Runs the SAME detection layers the Analyze pipeline uses — secretlint (secrets)
+// and our in-repo structured-PII regex — then applies the real text redactor. A
+// case passes only when BOTH hold:
+//   - recall: every `mustRedact` value is gone from the redacted text, and
+//   - precision: every `mustKeep` value survives, and clean cases yield no findings.
+// This exercises detection and redaction end to end: a raw value that is detected
+// but not masked (or masked but re-detectable) fails just like a miss.
+
+import {
+  redactText,
+  resolveOverlaps,
+  scanStructuredPii,
+  type SensitiveMatch,
+} from "../../common/sensitive";
+import { scanSecrets } from "../../electron/sensitive/secrets";
+import { sensitiveFrameBoxes, type FrameBox } from "../../electron/sensitive/frame-redact";
+import type { OcrWord } from "../../electron/sensitive/ocr";
+import type { SensitiveCase } from "./corpus";
+import type { FrameCase } from "./frames";
+
+export interface Check {
+  name: string;
+  kind: "recall" | "precision";
+  pass: boolean;
+  detail?: string;
+}
+
+export interface CaseScore {
+  id: string;
+  about: string;
+  pass: boolean;
+  score: number;
+  matchCount: number;
+  redacted: string;
+  checks: Check[];
+}
+
+/** All detection layers merged and de-overlapped, exactly as the scanner does. */
+export async function detect(text: string): Promise<SensitiveMatch[]> {
+  const secrets = await scanSecrets(text);
+  const pii = scanStructuredPii(text);
+  return resolveOverlaps([...secrets, ...pii]);
+}
+
+const short = (s: string): string => (s.length <= 24 ? s : `${s.slice(0, 10)}…${s.slice(-6)}`);
+
+export async function scoreCase(c: SensitiveCase): Promise<CaseScore> {
+  const matches = await detect(c.text);
+  const redacted = redactText(c.text, matches);
+  const checks: Check[] = [];
+
+  for (const value of c.mustRedact) {
+    const gone = !redacted.includes(value);
+    checks.push({
+      name: `redacts ${short(value)}`,
+      kind: "recall",
+      pass: gone,
+      detail: gone ? undefined : "raw value still present after redaction",
+    });
+  }
+
+  for (const keep of c.mustKeep) {
+    const kept = redacted.includes(keep);
+    checks.push({
+      name: `keeps ${short(keep)}`,
+      kind: "precision",
+      pass: kept,
+      detail: kept ? undefined : "expected-clean text was masked (over-redaction)",
+    });
+  }
+
+  if (c.mustRedact.length === 0) {
+    checks.push({
+      name: "no findings on clean text",
+      kind: "precision",
+      pass: matches.length === 0,
+      detail: matches.length === 0 ? undefined : `flagged ${matches.length} span(s)`,
+    });
+  }
+
+  const passed = checks.filter((c) => c.pass).length;
+  return {
+    id: c.id,
+    about: c.about,
+    pass: passed === checks.length,
+    score: checks.length ? passed / checks.length : 1,
+    matchCount: matches.length,
+    redacted,
+    checks,
+  };
+}
+
+export interface Totals {
+  recallPass: number;
+  recallTotal: number;
+  precisionPass: number;
+  precisionTotal: number;
+}
+
+export function tally(scores: CaseScore[]): Totals {
+  const totals: Totals = { recallPass: 0, recallTotal: 0, precisionPass: 0, precisionTotal: 0 };
+  for (const s of scores) {
+    for (const check of s.checks) {
+      if (check.kind === "recall") {
+        totals.recallTotal += 1;
+        if (check.pass) totals.recallPass += 1;
+      } else {
+        totals.precisionTotal += 1;
+        if (check.pass) totals.precisionPass += 1;
+      }
+    }
+  }
+  return totals;
+}
+
+/* --- Frame OCR + blur scoring ---------------------------------------------- */
+
+const ROW_TOP = 10;
+const ROW_BOTTOM = 40;
+const WORD_WIDTH = 100;
+const WORD_STRIDE = 160; // wide gap so a padded box only overlaps its own word
+
+interface PlacedWord {
+  ocr: OcrWord;
+  sensitive: boolean;
+}
+
+/** Lay frame words out left-to-right on one row with wide gaps between them. */
+function placeWords(frame: FrameCase): { words: PlacedWord[]; width: number; height: number } {
+  const words = frame.words.map((w, i) => {
+    const x0 = 10 + i * WORD_STRIDE;
+    return {
+      ocr: { text: w.text, confidence: 95, bbox: { x0, y0: ROW_TOP, x1: x0 + WORD_WIDTH, y1: ROW_BOTTOM } },
+      sensitive: Boolean(w.sensitive),
+    };
+  });
+  const width = 20 + frame.words.length * WORD_STRIDE;
+  return { words, height: 60, width };
+}
+
+/** True when a returned blur box overlaps a word's original bounding box. */
+function overlaps(box: FrameBox, word: OcrWord): boolean {
+  return (
+    box.left < word.bbox.x1 &&
+    word.bbox.x0 < box.left + box.width &&
+    box.top < word.bbox.y1 &&
+    word.bbox.y0 < box.top + box.height
+  );
+}
+
+export async function scoreFrameCase(frame: FrameCase): Promise<CaseScore> {
+  const { words, width, height } = placeWords(frame);
+  const boxes = await sensitiveFrameBoxes(
+    words.map((w) => w.ocr),
+    {
+      width,
+      height,
+      knownValues: frame.knownValues ?? [],
+    },
+  );
+
+  const checks: Check[] = [];
+  for (const placed of words) {
+    const blurred = boxes.some((b) => overlaps(b, placed.ocr));
+    if (placed.sensitive) {
+      checks.push({
+        name: `blurs "${placed.ocr.text}"`,
+        kind: "recall",
+        pass: blurred,
+        detail: blurred ? undefined : "sensitive word left visible",
+      });
+    } else {
+      checks.push({
+        name: `keeps "${placed.ocr.text}" visible`,
+        kind: "precision",
+        pass: !blurred,
+        detail: blurred ? "ordinary word was blurred (over-redaction)" : undefined,
+      });
+    }
+  }
+
+  const passed = checks.filter((c) => c.pass).length;
+  const blurredCount = words.filter((w) => boxes.some((b) => overlaps(b, w.ocr))).length;
+  return {
+    id: frame.id,
+    about: frame.about,
+    pass: passed === checks.length,
+    score: checks.length ? passed / checks.length : 1,
+    matchCount: boxes.length,
+    redacted: `blurred ${blurredCount}/${words.length} word(s)`,
+    checks,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,16 @@
       "dependencies": {
         "@github/copilot-sdk": "^1.0.6",
         "@huggingface/transformers": "^4.2.0",
+        "@secretlint/core": "^13.0.4",
+        "@secretlint/secretlint-rule-pattern": "^13.0.4",
+        "@secretlint/secretlint-rule-preset-recommend": "^13.0.4",
         "archiver": "^7.0.1",
         "koffi": "^3.1.1",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "sharp": "^0.34.5",
+        "tesseract.js": "^7.0.0",
+        "tesseract.js-core": "^7.0.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -2066,6 +2071,111 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@secretlint/config-loader": {
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/@secretlint/config-loader/-/config-loader-13.0.4.tgz",
+      "integrity": "sha1-WSPjcnx5gEt+cUUex082fTV8sE0=",
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/profiler": "13.0.4",
+        "@secretlint/resolver": "13.0.4",
+        "@secretlint/types": "13.0.4",
+        "ajv": "^8.20.0",
+        "debug": "^4.4.3",
+        "rc-config-loader": "^4.1.4"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@secretlint/core": {
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/@secretlint/core/-/core-13.0.4.tgz",
+      "integrity": "sha1-Z2IgAng6TdngGDjeF4AMOGR+AkQ=",
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/profiler": "13.0.4",
+        "@secretlint/types": "13.0.4",
+        "debug": "^4.4.3",
+        "structured-source": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@secretlint/profiler": {
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/@secretlint/profiler/-/profiler-13.0.4.tgz",
+      "integrity": "sha1-BXXcj5ToZhz1Ai8YCJ+Z6K2532o=",
+      "license": "MIT"
+    },
+    "node_modules/@secretlint/resolver": {
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/@secretlint/resolver/-/resolver-13.0.4.tgz",
+      "integrity": "sha1-bk7n6maNrbesKQizpmN/3hhsLgA=",
+      "license": "MIT"
+    },
+    "node_modules/@secretlint/secretlint-rule-pattern": {
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-pattern/-/secretlint-rule-pattern-13.0.4.tgz",
+      "integrity": "sha1-ylFNynkxU9Tok69bbqFfW5xA8nw=",
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/tester": "13.0.4",
+        "@secretlint/types": "13.0.4",
+        "@textlint/regexp-string-matcher": "^2.0.2",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@secretlint/secretlint-rule-preset-recommend": {
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-preset-recommend/-/secretlint-rule-preset-recommend-13.0.4.tgz",
+      "integrity": "sha1-RcgmC3EMD/auSqdymqZEwnd/KBM=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@secretlint/source-creator": {
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/@secretlint/source-creator/-/source-creator-13.0.4.tgz",
+      "integrity": "sha1-C2Qn9jFkg2hc+JIRw3YF/y2zIpw=",
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/types": "13.0.4",
+        "istextorbinary": "^9.5.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@secretlint/tester": {
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/@secretlint/tester/-/tester-13.0.4.tgz",
+      "integrity": "sha1-1UGL/K1IQ7X3U42iXNsXJ9gP850=",
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/config-loader": "13.0.4",
+        "@secretlint/core": "13.0.4",
+        "@secretlint/source-creator": "13.0.4",
+        "@secretlint/types": "13.0.4"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@secretlint/types": {
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/@secretlint/types/-/types-13.0.4.tgz",
+      "integrity": "sha1-6r3UYbFbma06TItkJlxi1AJXEpQ=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -2090,6 +2200,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@textlint/regexp-string-matcher": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@textlint/regexp-string-matcher/-/regexp-string-matcher-2.0.2.tgz",
+      "integrity": "sha1-zvTYNT2sYkCGBp4pDZYxyihd800=",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "lodash.sortby": "^4.7.0",
+        "lodash.uniq": "^4.5.0",
+        "lodash.uniqwith": "^4.5.0"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -2664,7 +2786,6 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha1-MEs2Nq3Yi6fZNnYN1Q7OAG3qlfk=",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -3009,7 +3130,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/asn1js": {
@@ -3191,11 +3311,32 @@
       ],
       "license": "MIT"
     },
+    "node_modules/binaryextensions": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-6.11.0.tgz",
+      "integrity": "sha1-w2s+a1xZ5iFgVwmwmc2o3agkzHI=",
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "editions": "^6.21.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28=",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bmp-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+      "integrity": "sha1-4Fpj95amwf8l9Hcex62twUjAcjM=",
       "license": "MIT"
     },
     "node_modules/boolean": {
@@ -3204,6 +3345,12 @@
       "integrity": "sha1-nlKUr06YMUSUy7F5efpUyhWfEWs=",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT"
+    },
+    "node_modules/boundary": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/boundary/-/boundary-2.0.0.tgz",
+      "integrity": "sha1-FpyLHw1Ezywlk4lnoyjzfgpOXvw=",
+      "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
       "version": "5.0.7",
@@ -3216,6 +3363,18 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha1-SQMy9AkZRSJy1VqEgK3AxEE1h4k=",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/buffer": {
@@ -3859,7 +4018,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4125,6 +4283,22 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha1-aWzi7Aqg5uqTo5f/zySqeEDIJ8s=",
       "license": "MIT"
+    },
+    "node_modules/editions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-6.22.0.tgz",
+      "integrity": "sha1-ORPE7qmqRYbhe80l1k1e3xeQZXo=",
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "version-range": "^4.15.0"
+      },
+      "engines": {
+        "ecmascript": ">= es5",
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -4461,7 +4635,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-fifo": {
@@ -4474,7 +4647,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
       "integrity": "sha1-9pWkDwBqulBWMVc6ACHdshGUrRE=",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4543,6 +4715,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha1-RCZdPKwH4+p9wkdRY4BkN1SgUpI=",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/flatbuffers": {
@@ -5285,6 +5469,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/idb-keyval": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.3.0.tgz",
+      "integrity": "sha1-P6TAYvyt3X5XfFG1H2mSS8z7WOY=",
+      "license": "Apache-2.0"
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -5369,6 +5559,15 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -5380,6 +5579,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha1-BKTfRtKMTP89c9Af8Gq+sxihqlI=",
+      "license": "MIT"
     },
     "node_modules/isarray": {
       "version": "1.0.0",
@@ -5408,6 +5613,23 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/istextorbinary": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-9.5.0.tgz",
+      "integrity": "sha1-5uE/6/HBaFEAriZICaT49G4B39M=",
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "binaryextensions": "^6.11.0",
+        "editions": "^6.21.0",
+        "textextensions": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
       }
     },
     "node_modules/jackspeak": {
@@ -5457,7 +5679,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
       "integrity": "sha1-0ZAFcqf3zwtfVAyDZz5gutNDZZI=",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5487,7 +5708,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI=",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
@@ -5500,7 +5720,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha1-eM1vGhm9wStz21rQxh79ZsHikoM=",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -5893,6 +6112,24 @@
       "integrity": "sha1-/ytmwfYybVlRPeJAe/iBQ5gSdxw=",
       "license": "MIT"
     },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniqwith": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz",
+      "integrity": "sha1-egy/ZfQ7WShiWp1NDcVLGMrcfvM=",
+      "license": "MIT"
+    },
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
@@ -6002,6 +6239,31 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha1-1m+hjzpHB2eJMgubGvMr2G2fogI=",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mime": {
@@ -6284,7 +6546,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -6354,7 +6615,6 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha1-0PD6bj4twdJ+/NitmdVQvalNGH0=",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -6597,6 +6857,15 @@
       "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.0-dev.20251116-b39e144322.tgz",
       "integrity": "sha1-bt7PTlF4+ddpB9WrviQcNjXlKN0=",
       "license": "MIT"
+    },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha1-eg//l49tv6TQBiOPusmO1BmMMlk=",
+      "license": "MIT",
+      "bin": {
+        "opencollective-postinstall": "index.js"
+      }
     },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
@@ -6997,6 +7266,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/rc-config-loader": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-4.1.4.tgz",
+      "integrity": "sha1-bMeQQqwZPr7Z8IL8unuCPZ3BQ8w=",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "js-yaml": "^4.1.1",
+        "json5": "^2.2.3",
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
@@ -7082,6 +7363,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha1-9tyj587sIFkNB62nhWNqkM3KF/k=",
+      "license": "MIT"
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7096,7 +7383,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha1-iaf92TgmEmcxjq/hT5wy5ZjDaQk=",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7571,6 +7857,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/structured-source": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-4.0.0.tgz",
+      "integrity": "sha1-DJ5Z7kPe3Y/GCmNzH2DjWBAqSUg=",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boundary": "^2.0.0"
+      }
+    },
     "node_modules/sumchecker": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
@@ -7686,6 +7981,30 @@
         "rimraf": "bin.js"
       }
     },
+    "node_modules/tesseract.js": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-7.0.0.tgz",
+      "integrity": "sha1-QQb7YkXvq0DFe5S8F5g2iAdSa+g=",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bmp-js": "^0.1.0",
+        "idb-keyval": "^6.2.0",
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.9",
+        "opencollective-postinstall": "^2.0.3",
+        "regenerator-runtime": "^0.13.3",
+        "tesseract.js-core": "^7.0.0",
+        "wasm-feature-detect": "^1.8.0",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/tesseract.js-core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-7.0.0.tgz",
+      "integrity": "sha1-WWqhq1wTCtqxLyEFnmqhoc7MC6s=",
+      "license": "Apache-2.0"
+    },
     "node_modules/text-decoder": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
@@ -7693,6 +8012,21 @@
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/textextensions": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-6.11.0.tgz",
+      "integrity": "sha1-hkU10J9JAmFQyW8LDXnx+ghp2xU=",
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "editions": "^6.21.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
       }
     },
     "node_modules/tiny-async-pool": {
@@ -7752,12 +8086,23 @@
         "tmp": "^0.2.0"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
@@ -7925,6 +8270,18 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "license": "MIT"
     },
+    "node_modules/version-range": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/version-range/-/version-range-4.15.0.tgz",
+      "integrity": "sha1-id8ekhsU03UVqrXkLtSsBRXKssE=",
+      "license": "Artistic-2.0",
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
     "node_modules/vite": {
       "version": "8.1.5",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
@@ -8030,6 +8387,12 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha1-Tp9VsKZNgB83L7sDJO0RrTq9DHg=",
+      "license": "Apache-2.0"
+    },
     "node_modules/webcrypto-core": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.9.2.tgz",
@@ -8048,15 +8411,13 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-      "license": "BSD-2-Clause",
-      "optional": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -8228,6 +8589,15 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha1-UBl+2yihxCymWcyLTmqd3W1ERVQ=",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -19,10 +19,13 @@
     "check:lockfile": "node scripts/check-lockfile-portability.mjs",
     "typecheck": "tsc --noEmit",
     "typecheck:evals": "tsc --noEmit -p evals/tsconfig.json",
-    "test": "node --experimental-transform-types --no-warnings --import ./evals/register.mjs --test evals/builder-imports.test.ts common/architecture-registry.test.ts electron/architectures/catalogue-registry.test.ts common/audio.test.ts common/microphone.test.ts common/narration.test.ts electron/recording-controls-bounds.test.ts electron/recording-privacy.test.ts electron/crash-guards.test.ts electron/recorder/controller.test.ts electron/recorder/session-store.test.ts electron/frames/extractor.test.ts electron/narration/audio-analysis.test.ts electron/narration/analyze-gate.test.ts electron/narration/transcribe.test.ts electron/narration/whisper.test.ts electron/sessions.test.ts electron/debug-bundle.test.ts electron/skillbuilder/placement.test.ts src/skill-placement.test.ts scripts/compliance.test.mjs",
+    "test": "node --experimental-transform-types --no-warnings --import ./evals/register.mjs --test evals/builder-imports.test.ts common/architecture-registry.test.ts electron/architectures/catalogue-registry.test.ts common/audio.test.ts common/microphone.test.ts common/narration.test.ts common/sensitive.test.ts electron/recording-controls-bounds.test.ts electron/recording-privacy.test.ts electron/crash-guards.test.ts electron/recorder/controller.test.ts electron/recorder/session-store.test.ts electron/frames/extractor.test.ts electron/narration/audio-analysis.test.ts electron/narration/analyze-gate.test.ts electron/narration/transcribe.test.ts electron/narration/whisper.test.ts electron/sensitive/scanner.test.ts electron/sensitive/secrets.test.ts electron/sensitive/tessdata-source.test.ts electron/sensitive/ocr.test.ts electron/sensitive/frame-redact.test.ts electron/sensitive/frame-heuristics.test.ts electron/sessions.test.ts electron/debug-bundle.test.ts electron/skillbuilder/placement.test.ts src/skill-placement.test.ts scripts/compliance.test.mjs",
     "eval": "node --experimental-transform-types --no-warnings --import ./evals/register.mjs evals/run.ts",
     "eval:builder": "node --experimental-transform-types --no-warnings --import ./evals/register.mjs evals/builder/run.ts",
     "eval:skill": "node --experimental-transform-types --no-warnings --import ./evals/register.mjs evals/skillbuilder/run.ts",
+    "eval:sensitive": "node --experimental-transform-types --no-warnings --import ./evals/register.mjs evals/sensitive/run.ts",
+    "eval:sensitive:ocr": "node --experimental-transform-types --no-warnings --import ./evals/register.mjs evals/sensitive/ocr-images.ts",
+    "eval:sensitive:realistic": "node --experimental-transform-types --no-warnings --import ./evals/register.mjs evals/sensitive/ocr-realistic.ts",
     "electron:install-reviewed": "node scripts/install-reviewed-electron.mjs",
     "compliance:licenses": "node scripts/prepare-compliance.mjs --licenses-only",
     "compliance:prepare": "node scripts/prepare-compliance.mjs",
@@ -38,11 +41,16 @@
   "dependencies": {
     "@github/copilot-sdk": "^1.0.6",
     "@huggingface/transformers": "^4.2.0",
+    "@secretlint/core": "^13.0.4",
+    "@secretlint/secretlint-rule-pattern": "^13.0.4",
+    "@secretlint/secretlint-rule-preset-recommend": "^13.0.4",
     "archiver": "^7.0.1",
     "koffi": "^3.1.1",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "sharp": "^0.34.5",
+    "tesseract.js": "^7.0.0",
+    "tesseract.js-core": "^7.0.0",
     "zod": "^4.3.6"
   },
   "optionalDependencies": {
@@ -70,7 +78,8 @@
     "koffi@3.1.1": true,
     "onnxruntime-node@1.24.3": true,
     "protobufjs": false,
-    "sharp@0.34.5": true
+    "sharp@0.34.5": true,
+    "tesseract.js": false
   },
   "build": {
     "appId": "com.skillrecorder.app",
@@ -101,7 +110,9 @@
       "node_modules/@koromix/**",
       "node_modules/@github/copilot-*/**",
       "node_modules/@huggingface/transformers/**",
-      "node_modules/onnxruntime-node/**"
+      "node_modules/onnxruntime-node/**",
+      "node_modules/tesseract.js/**",
+      "node_modules/tesseract.js-core/**"
     ],
     "mac": {
       "icon": "build/icon.png",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "electron:install-reviewed": "node scripts/install-reviewed-electron.mjs",
     "compliance:licenses": "node scripts/prepare-compliance.mjs --licenses-only",
     "compliance:prepare": "node scripts/prepare-compliance.mjs",
+    "compliance:review": "node scripts/review-compliance-sources.mjs",
     "compliance:test": "node --test scripts/compliance.test.mjs",
     "fix:lockfile-registry": "node scripts/check-lockfile-portability.mjs --fix",
     "dist": "npm run compliance:prepare && node scripts/assert-generic-dist-platform.mjs && npm run build:vite && electron-builder --publish never",

--- a/scripts/compliance.mjs
+++ b/scripts/compliance.mjs
@@ -18,6 +18,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { pipeline } from "node:stream/promises";
 import { Readable } from "node:stream";
@@ -48,6 +49,9 @@ const gccLicenseMirror =
 const mozillaLicenseRevision = "6efbc1d7604a22fae6ba145d1c3637f0bec7b1e6";
 const mozillaLicense =
   `https://raw.githubusercontent.com/mozilla/grcov/${mozillaLicenseRevision}`;
+const spdxLicenseRevision = "b8d6af45ad2fcfed61bb85a8ad068aa4a77eadf9";
+const spdxLicenseText =
+  `https://raw.githubusercontent.com/spdx/license-list-data/${spdxLicenseRevision}/text`;
 const licenseFilePattern =
   /^(?:(?:licen[cs]e|copying|notice|copyright)(?:[-._].*)?|third[-_. ]?party[-_. ]?notices?(?:[-._].*)?)$/i;
 const requiredComplianceFiles = [
@@ -88,7 +92,123 @@ export const legalTextSpecs = [
     url: `${mozillaLicense}/LICENSE-MPL-2.0`,
     marker: "Mozilla Public License Version 2.0",
   },
+  {
+    id: "artistic-2.0",
+    fileName: "Artistic-2.0.txt",
+    url: `${spdxLicenseText}/Artistic-2.0.txt`,
+    marker: "The Artistic License 2.0",
+  },
 ];
+
+const tesseractCoreSources = {
+  core: {
+    archiveName: "tesseract-js-core",
+    gitRepository: "https://github.com/naptha/tesseract.js-core.git",
+    webBase: "https://github.com/naptha/tesseract.js-core/tree",
+  },
+  giflib: {
+    archiveName: "tesseract-core-giflib",
+    gitRepository: "https://github.com/mirrorer/giflib.git",
+    rawBase: "https://raw.githubusercontent.com/mirrorer/giflib",
+    webBase: "https://github.com/mirrorer/giflib/tree",
+  },
+  leptonica: {
+    archiveName: "tesseract-core-leptonica",
+    gitRepository: "https://github.com/DanBloomberg/leptonica.git",
+    rawBase: "https://raw.githubusercontent.com/DanBloomberg/leptonica",
+    webBase: "https://github.com/DanBloomberg/leptonica/tree",
+  },
+  libjpeg: {
+    archiveName: "tesseract-core-libjpeg",
+    gitRepository: "https://github.com/LuaDist/libjpeg.git",
+    rawBase: "https://raw.githubusercontent.com/LuaDist/libjpeg",
+    webBase: "https://github.com/LuaDist/libjpeg/tree",
+  },
+  libpng: {
+    archiveName: "tesseract-core-libpng",
+    gitRepository: "https://github.com/glennrp/libpng.git",
+    rawBase: "https://raw.githubusercontent.com/glennrp/libpng",
+    webBase: "https://github.com/glennrp/libpng/tree",
+  },
+  libtiff: {
+    archiveName: "tesseract-core-libtiff",
+    gitRepository: "https://gitlab.com/libtiff/libtiff.git",
+    rawBase: "https://gitlab.com/libtiff/libtiff/-/raw",
+    webBase: "https://gitlab.com/libtiff/libtiff/-/tree",
+  },
+  libwebp: {
+    archiveName: "tesseract-core-libwebp",
+    gitRepository: "https://github.com/webmproject/libwebp.git",
+    rawBase: "https://raw.githubusercontent.com/webmproject/libwebp",
+    webBase: "https://github.com/webmproject/libwebp/tree",
+  },
+  openlibm: {
+    archiveName: "tesseract-core-openlibm",
+    gitRepository: "https://github.com/JuliaMath/openlibm.git",
+    rawBase: "https://raw.githubusercontent.com/JuliaMath/openlibm",
+    webBase: "https://github.com/JuliaMath/openlibm/tree",
+  },
+  tesseract: {
+    archiveName: "tesseract-core-tesseract",
+    gitRepository: "https://github.com/Balearica/tesseract.git",
+    rawBase: "https://raw.githubusercontent.com/Balearica/tesseract",
+    webBase: "https://github.com/Balearica/tesseract/tree",
+  },
+  zlib: {
+    archiveName: "tesseract-core-zlib",
+    gitRepository: "https://github.com/madler/zlib.git",
+    rawBase: "https://raw.githubusercontent.com/madler/zlib",
+    webBase: "https://github.com/madler/zlib/tree",
+  },
+};
+
+const tesseractCoreNoticeFiles = {
+  giflib: {
+    path: "COPYING",
+    outputFile: "giflib-COPYING.txt",
+    marker: "The GIFLIB distribution is Copyright",
+  },
+  leptonica: {
+    path: "leptonica-license.txt",
+    outputFile: "leptonica-LICENSE.txt",
+    marker: "Copyright (C) 2001-2020 Leptonica",
+  },
+  libjpeg: {
+    path: "README",
+    outputFile: "libjpeg-README.txt",
+    marker: "LEGAL ISSUES",
+  },
+  libpng: {
+    path: "LICENSE",
+    outputFile: "libpng-LICENSE.txt",
+    marker: "PNG Reference Library License version 2",
+  },
+  libtiff: {
+    path: "COPYRIGHT",
+    outputFile: "libtiff-COPYRIGHT.txt",
+    marker: "Copyright (c) 1988-1997 Sam Leffler",
+  },
+  libwebp: {
+    path: "COPYING",
+    outputFile: "libwebp-COPYING.txt",
+    marker: "Copyright (c) 2010, Google Inc.",
+  },
+  openlibm: {
+    path: "LICENSE.md",
+    outputFile: "openlibm-LICENSE.md",
+    marker: "OpenLibm contains code that is covered by various licenses.",
+  },
+  tesseract: {
+    path: "LICENSE",
+    outputFile: "tesseract-LICENSE.txt",
+    marker: "Apache License",
+  },
+  zlib: {
+    path: "README",
+    outputFile: "zlib-README.txt",
+    marker: "ZLIB DATA COMPRESSION LIBRARY",
+  },
+};
 
 const sourceBuilders = {
   aom: (version) => ({
@@ -422,6 +542,176 @@ export function buildNativeSourceSpecs(
   return specs.sort((a, b) => a.id.localeCompare(b.id));
 }
 
+function assertExactKeys(value, expected, label) {
+  const actual = Object.keys(value ?? {}).sort();
+  const sortedExpected = [...expected].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(sortedExpected)) {
+    throw new Error(
+      `${label} differ from the reviewed set; expected ${sortedExpected.join(", ")}, ` +
+        `found ${actual.join(", ") || "(none)"}.`,
+    );
+  }
+}
+
+function reviewedTesseractSourceRevisions(tesseract) {
+  const expected = Object.keys(tesseractCoreSources);
+  assertExactKeys(tesseract?.sourceRevisions, expected, "Tesseract source revisions");
+  for (const [name, revision] of Object.entries(tesseract.sourceRevisions)) {
+    if (!/^[a-f0-9]{40}$/.test(revision)) {
+      throw new Error(`Tesseract ${name} source revision must be a full Git commit.`);
+    }
+  }
+  return tesseract.sourceRevisions;
+}
+
+export function buildTesseractSourceSpecs(tesseract) {
+  if (!/^\d+\.\d+\.\d+$/.test(tesseract?.coreVersion ?? "")) {
+    throw new Error("Tesseract.js-core must have a reviewed exact version.");
+  }
+  const revisions = reviewedTesseractSourceRevisions(tesseract);
+  return Object.entries(tesseractCoreSources)
+    .map(([name, source]) => {
+      const revision = revisions[name];
+      const isCore = name === "core";
+      return {
+        id: isCore
+          ? `tesseract-js-core@${tesseract.coreVersion}`
+          : `tesseract-core-${name}@${revision}`,
+        version: isCore ? tesseract.coreVersion : revision,
+        fileName: `${source.archiveName}-${revision}.tar`,
+        url: `${source.webBase}/${revision}`,
+        gitRepository: source.gitRepository,
+        gitRevision: revision,
+        archivePrefix: `${source.archiveName}-${revision}/`,
+        reason: isCore
+          ? "Build scripts and source for the packaged Tesseract WebAssembly runtime."
+          : `Source and license material for ${name}, statically linked into Tesseract WebAssembly.`,
+      };
+    })
+    .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function packageNameFromLockPath(lockPath) {
+  return lockPath.split("node_modules/").at(-1);
+}
+
+export function buildArtisticSourceSpecs(lock, reviewedPackages) {
+  const installed = new Map();
+  for (const [lockPath, entry] of Object.entries(lock.packages ?? {})) {
+    if (!lockPath || entry.dev || entry.license !== "Artistic-2.0") continue;
+    const name = packageNameFromLockPath(lockPath);
+    const versions = installed.get(name) ?? new Set();
+    versions.add(entry.version);
+    installed.set(name, versions);
+  }
+
+  assertExactKeys(
+    Object.fromEntries(installed),
+    Object.keys(reviewedPackages ?? {}),
+    "Artistic-2.0 packages",
+  );
+  return Object.entries(reviewedPackages ?? {})
+    .map(([name, version]) => {
+      const versions = installed.get(name);
+      if (versions?.size !== 1 || !versions.has(version)) {
+        throw new Error(
+          `${name} Artistic-2.0 versions have not been reviewed: ` +
+            `${[...(versions ?? [])].join(", ") || "(missing)"}; expected ${version}.`,
+        );
+      }
+      if (name.includes("/")) {
+        throw new Error(`Scoped Artistic-2.0 package ${name} needs an explicit source URL.`);
+      }
+      return {
+        id: `npm-source-${name}@${version}`,
+        version,
+        fileName: `${name}-${version}.tgz`,
+        url: `https://registry.npmjs.org/${name}/-/${name}-${version}.tgz`,
+        reason:
+          "Verbatim Standard Version source for an Artistic-2.0 package distributed with the app.",
+      };
+    })
+    .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+export function buildComplianceSourceSpecs(nativeVersions, lock, policy, platform) {
+  return [
+    ...buildNativeSourceSpecs(nativeVersions, {
+      platform,
+      sharpVersion: policy.sharp,
+      sharpLibvipsVersion: policy.sharpLibvips.version,
+      electronVersion: policy.electron.version,
+      ffmpegRevision: policy.electron.ffmpegRevision,
+    }),
+    ...buildTesseractSourceSpecs(policy.tesseract),
+    ...buildArtisticSourceSpecs(lock, policy.artisticPackages),
+  ].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+export function buildTesseractNoticeSpecs(tesseract) {
+  const revisions = reviewedTesseractSourceRevisions(tesseract);
+  const specs = Object.entries(tesseractCoreNoticeFiles).map(([name, notice]) => {
+    const source = tesseractCoreSources[name];
+    const revision = revisions[name];
+    return {
+      id: `tesseract-core-${name}-license`,
+      fileName: `tesseract-core-${notice.outputFile}`,
+      outputPath: `tesseract-core/${notice.outputFile}`,
+      url: `${source.rawBase}/${revision}/${notice.path}`,
+      marker: notice.marker,
+    };
+  });
+
+  const tessdataRevision = tesseract?.tessdata?.revision;
+  if (!/^[a-f0-9]{40}$/.test(tessdataRevision ?? "")) {
+    throw new Error("Tesseract tessdata revision must be a full Git commit.");
+  }
+  specs.push({
+    id: "tessdata-fast-license",
+    fileName: "tessdata-fast-LICENSE.txt",
+    outputPath: "tesseract-core/tessdata-fast-LICENSE.txt",
+    url:
+      `https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/` +
+      `${tessdataRevision}/LICENSE`,
+    marker: "Apache License",
+  });
+  return specs.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+export function buildStaticRemoteMaterialSpecs(policy) {
+  return [
+    ...legalTextSpecs.map((spec) => ({
+      ...spec,
+      outputPath: `licenses/${spec.fileName}`,
+    })),
+    ...buildTesseractNoticeSpecs(policy.tesseract),
+  ].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+export function assertReviewedTessdataPins(source, tessdata) {
+  const revision = source.match(/export const TESSDATA_COMMIT = "([a-f0-9]{40})"/)?.[1];
+  if (revision !== tessdata?.revision) {
+    throw new Error(
+      `Runtime tessdata revision ${revision ?? "(missing)"} has not been reviewed; ` +
+        `expected ${tessdata?.revision ?? "(missing)"}.`,
+    );
+  }
+
+  const block = source.match(/export const TESSDATA_SHA256:[\s\S]*?=\s*\{([\s\S]*?)\};/)?.[1];
+  if (!block) throw new Error("Runtime tessdata SHA-256 map could not be read.");
+  const runtimeFiles = Object.fromEntries(
+    [...block.matchAll(/^\s*([A-Za-z0-9_-]+):\s*"([a-f0-9]{64})",?\s*$/gm)].map(
+      ([, name, sha256]) => [`${name}.traineddata`, sha256],
+    ),
+  );
+  assertExactKeys(runtimeFiles, Object.keys(tessdata.files ?? {}), "Tessdata files");
+  for (const [name, sha256] of Object.entries(tessdata.files ?? {})) {
+    if (runtimeFiles[name] !== sha256) {
+      throw new Error(`Runtime tessdata hash for ${name} does not match the reviewed policy.`);
+    }
+  }
+}
+
 export async function prepareCompliance({
   rootDir = repositoryRoot,
   outputDir = complianceOutput,
@@ -433,7 +723,7 @@ export async function prepareCompliance({
   const policy = readJson(path.join(rootDir, "third_party", "compliance-policy.json"));
   const lock = readJson(path.join(rootDir, "package-lock.json"));
   const packages = collectProductionPackages(rootDir, lock);
-  validateReviewedVersions(packages, lock, policy);
+  validateReviewedVersions(packages, lock, policy, rootDir);
   await removeStalePartialFiles(path.join(rootDir, ".compliance-cache"));
 
   await rm(outputDir, { recursive: true, force: true });
@@ -493,6 +783,7 @@ export async function prepareCompliance({
         outputDir,
         rootDir,
         policy,
+        lock,
         nativeVersions: native.versions,
         fetchImpl,
       })
@@ -584,13 +875,13 @@ export async function verifyComplianceDirectory(
   }
   if (requireSources) {
     const native = readJson(path.join(directory, "NATIVE-COMPONENTS.json"));
-    const expectedSources = buildNativeSourceSpecs(native.versions, {
-      platform: native.platform,
-      sharpVersion: policy.sharp,
-      sharpLibvipsVersion: policy.sharpLibvips.version,
-      electronVersion: policy.electron.version,
-      ffmpegRevision: policy.electron.ffmpegRevision,
-    });
+    const lock = readJson(path.join(repositoryRoot, "package-lock.json"));
+    const expectedSources = buildComplianceSourceSpecs(
+      native.versions,
+      lock,
+      policy,
+      native.platform,
+    );
     assertExactManifestIds(
       sources.sources,
       expectedSources.map(({ id }) => id),
@@ -701,10 +992,24 @@ function collectProductionPackages(rootDir, lock) {
   );
 }
 
-function validateReviewedVersions(packages, lock, policy) {
+function validateReviewedVersions(packages, lock, policy, rootDir) {
   assertInstalledVersion(packages, "@github/copilot-sdk", policy.copilotSdk);
   assertReviewedCopilotCliVersions(lock, policy.copilotCli);
   assertInstalledVersion(packages, "sharp", policy.sharp);
+  for (const name of [
+    "@secretlint/core",
+    "@secretlint/secretlint-rule-pattern",
+    "@secretlint/secretlint-rule-preset-recommend",
+  ]) {
+    assertInstalledVersion(packages, name, policy.secretlint);
+  }
+  assertInstalledVersion(packages, "tesseract.js", policy.tesseract.jsVersion);
+  assertInstalledVersion(packages, "tesseract.js-core", policy.tesseract.coreVersion);
+  buildArtisticSourceSpecs(lock, policy.artisticPackages);
+  assertReviewedTessdataPins(
+    readFileSync(path.join(rootDir, "electron", "sensitive", "tessdata-source.ts"), "utf8"),
+    policy.tesseract.tessdata,
+  );
 
   const electronVersion = lock.packages?.["node_modules/electron"]?.version;
   if (electronVersion !== policy.electron.version) {
@@ -768,6 +1073,31 @@ function assertInstalledVersion(packages, name, expected) {
 function buildLicenseInventory(rootDir, packages, policy) {
   return packages.map((pkg) => {
     const files = findPackageLicenseFiles(pkg.directory);
+
+    if (pkg.license === "Artistic-2.0") {
+      if (files.length === 0) {
+        throw new Error(`${pkg.name}@${pkg.version} is missing its Artistic-2.0 notice.`);
+      }
+      return {
+        name: pkg.name,
+        version: pkg.version,
+        license: pkg.license,
+        packagePath: pkg.lockPath,
+        licenseSource: `${files.join(", ")}, licenses/Artistic-2.0.txt`,
+        text: [
+          ...files.map(
+            (file) =>
+              `----- ${file} -----\n${readFileSync(
+                path.join(pkg.directory, ...file.split("/")),
+                "utf8",
+              ).trim()}`,
+          ),
+          "The complete Artistic License 2.0 accompanies this application at " +
+            "licenses/Artistic-2.0.txt. Verbatim package source is listed in " +
+            "SOURCE-MANIFEST.json for redistributable builds.",
+        ].join("\n\n"),
+      };
+    }
 
     if (files.length > 0) {
       return {
@@ -968,10 +1298,7 @@ async function prepareRemoteMaterials({
   policy,
   fetchImpl,
 }) {
-  const specs = legalTextSpecs.map((spec) => ({
-    ...spec,
-    outputPath: `licenses/${spec.fileName}`,
-  }));
+  const specs = buildStaticRemoteMaterialSpecs(policy);
 
   const onnxVersions = [
     ...new Set(
@@ -1037,16 +1364,16 @@ async function prepareSources({
   outputDir,
   rootDir,
   policy,
+  lock,
   nativeVersions,
   fetchImpl,
 }) {
-  const specs = buildNativeSourceSpecs(nativeVersions, {
-    platform: process.platform,
-    sharpVersion: policy.sharp,
-    sharpLibvipsVersion: policy.sharpLibvips.version,
-    electronVersion: policy.electron.version,
-    ffmpegRevision: policy.electron.ffmpegRevision,
-  });
+  const specs = buildComplianceSourceSpecs(
+    nativeVersions,
+    lock,
+    policy,
+    process.platform,
+  );
   const sources = await mapLimit(specs, 4, async (spec) => {
     const relative = `sources/${spec.fileName}`;
     const target = path.join(outputDir, "sources", spec.fileName);
@@ -1163,55 +1490,63 @@ async function obtainGitArchive(spec, cache, rootDir) {
   if (cacheIsValid) return;
 
   await rm(cache, { force: true });
-  const repository = path.join(rootDir, ".compliance-cache", "git", spec.id);
+  const repository = path.join(
+    tmpdir(),
+    "skill-recorder-compliance-git",
+    `${createHash("sha256").update(spec.id).digest("hex").slice(0, 16)}-${process.pid}`,
+  );
   const temporary = `${cache}.partial`;
   await rm(repository, { recursive: true, force: true });
   await rm(temporary, { force: true });
   await mkdir(repository, { recursive: true });
 
-  await runGit(["init", "--quiet"], repository);
-  await runGit(
-    [
-      "fetch",
-      "--depth=1",
-      "--no-tags",
-      "--quiet",
-      spec.gitRepository,
-      spec.gitRevision,
-    ],
-    repository,
-  );
-  const resolvedRevision = await runGit(["rev-parse", "FETCH_HEAD"], repository);
-  if (resolvedRevision !== spec.gitRevision) {
-    throw new Error(
-      `Fetched ${spec.id} revision ${resolvedRevision}; expected ${spec.gitRevision}.`,
+  try {
+    await runGit(["init", "--quiet"], repository);
+    await runGit(
+      [
+        "fetch",
+        "--depth=1",
+        "--no-tags",
+        "--quiet",
+        spec.gitRepository,
+        spec.gitRevision,
+      ],
+      repository,
     );
-  }
+    const resolvedRevision = await runGit(["rev-parse", "FETCH_HEAD"], repository);
+    if (resolvedRevision !== spec.gitRevision) {
+      throw new Error(
+        `Fetched ${spec.id} revision ${resolvedRevision}; expected ${spec.gitRevision}.`,
+      );
+    }
 
-  await runGit(
-    [
-      ...deterministicGitConfigArgs,
-      "archive",
-      "--format=tar",
-      `--prefix=${spec.archivePrefix}`,
-      `--output=${temporary}`,
-      "FETCH_HEAD",
-    ],
-    repository,
-  );
-  if (!(await hasExpectedFileHeader(spec.fileName, temporary))) {
-    await rm(temporary, { force: true });
-    throw new Error(`Generated source material ${spec.id} is not a valid tar archive.`);
-  }
-  const actualHash = await sha256File(temporary);
-  if (actualHash !== spec.expectedSha256) {
-    await rm(temporary, { force: true });
-    throw new Error(
-      `Generated source material ${spec.id} has SHA-256 ${actualHash}; ` +
-        `expected reviewed hash ${spec.expectedSha256}.`,
+    await runGit(
+      [
+        ...deterministicGitConfigArgs,
+        "archive",
+        "--format=tar",
+        `--prefix=${spec.archivePrefix}`,
+        `--output=${temporary}`,
+        "FETCH_HEAD",
+      ],
+      repository,
     );
+    if (!(await hasExpectedFileHeader(spec.fileName, temporary))) {
+      await rm(temporary, { force: true });
+      throw new Error(`Generated source material ${spec.id} is not a valid tar archive.`);
+    }
+    const actualHash = await sha256File(temporary);
+    if (actualHash !== spec.expectedSha256) {
+      await rm(temporary, { force: true });
+      throw new Error(
+        `Generated source material ${spec.id} has SHA-256 ${actualHash}; ` +
+          `expected reviewed hash ${spec.expectedSha256}.`,
+      );
+    }
+    await rename(temporary, cache);
+  } finally {
+    await rm(repository, { recursive: true, force: true });
   }
-  await rename(temporary, cache);
 }
 
 async function runGit(args, cwd) {
@@ -1367,10 +1702,11 @@ function renderComplianceReadme(includeSources) {
     "- `THIRD-PARTY-LICENSES.txt` contains per-package license and attribution text.",
     "- `NATIVE-THIRD-PARTY-NOTICES.md` identifies libraries embedded in native payloads.",
     "- `onnxruntime/` contains exact ONNX Runtime third-party notices.",
+    "- `tesseract-core/` contains notices for libraries embedded in the OCR WebAssembly.",
     includeSources
       ? "- `electron/` contains the exact Electron and Chromium notices from this build."
       : "- Electron notices are added when a redistributable build is prepared.",
-    "- `licenses/` contains the complete GPL, LGPL, and MPL license texts.",
+    "- `licenses/` contains complete GPL, LGPL, MPL, and Artistic-2.0 license texts.",
     "- `RELINKING.md` explains replacement and relinking of native libraries.",
     "- `SOURCE-MANIFEST.json` maps corresponding-source archives to their origins.",
     "",

--- a/scripts/compliance.test.mjs
+++ b/scripts/compliance.test.mjs
@@ -19,7 +19,13 @@ import {
 } from "./run-reviewed-electron.mjs";
 import {
   assertReviewedCopilotCliVersions,
+  assertReviewedTessdataPins,
+  buildArtisticSourceSpecs,
+  buildComplianceSourceSpecs,
   buildNativeSourceSpecs,
+  buildStaticRemoteMaterialSpecs,
+  buildTesseractNoticeSpecs,
+  buildTesseractSourceSpecs,
   deterministicGitConfigArgs,
   findPackageLicenseFiles,
   hasExpectedFileHeader,
@@ -67,6 +73,12 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 const repoManifest = JSON.parse(
   await readFile(path.join(repoRoot, "package.json"), "utf8"),
 );
+const repoLock = JSON.parse(
+  await readFile(path.join(repoRoot, "package-lock.json"), "utf8"),
+);
+const repoPolicy = JSON.parse(
+  await readFile(path.join(repoRoot, "third_party", "compliance-policy.json"), "utf8"),
+);
 
 test("license filenames include common suffixed forms", () => {
   assert.equal(isLicenseFileName("LICENSE"), true);
@@ -105,6 +117,81 @@ test("nested package legal files are discovered", async () => {
   } finally {
     await rm(root, { recursive: true, force: true });
   }
+});
+
+test("Tesseract WebAssembly source and notices are pinned to the reviewed build", () => {
+  const sources = buildTesseractSourceSpecs(repoPolicy.tesseract);
+  assert.equal(sources.length, 10);
+  assert.deepEqual(
+    new Set(sources.map(({ id }) => id)),
+    new Set([
+      "tesseract-js-core@7.0.0",
+      ...Object.entries(repoPolicy.tesseract.sourceRevisions)
+        .filter(([name]) => name !== "core")
+        .map(([name, revision]) => `tesseract-core-${name}@${revision}`),
+    ]),
+  );
+  for (const source of sources) {
+    assert.match(source.gitRevision, /^[a-f0-9]{40}$/);
+    assert.match(source.url, new RegExp(`${source.gitRevision}$`));
+    assert.match(source.fileName, /\.tar$/);
+  }
+
+  const notices = buildTesseractNoticeSpecs(repoPolicy.tesseract);
+  assert.equal(notices.length, 10);
+  assert(notices.some(({ id }) => id === "tessdata-fast-license"));
+  for (const notice of notices) {
+    assert.doesNotMatch(notice.url, /\/(?:master|main|HEAD)(?:\/|$)/);
+    assert.match(notice.outputPath, /^tesseract-core\//);
+    assert.match(repoPolicy.remoteMaterials[notice.id], /^[a-f0-9]{64}$/);
+  }
+});
+
+test("runtime tessdata pins match the reviewed model policy", async () => {
+  const source = await readFile(
+    path.join(repoRoot, "electron", "sensitive", "tessdata-source.ts"),
+    "utf8",
+  );
+  assert.doesNotThrow(() =>
+    assertReviewedTessdataPins(source, repoPolicy.tesseract.tessdata),
+  );
+  assert.throws(
+    () =>
+      assertReviewedTessdataPins(
+        source.replace(repoPolicy.tesseract.tessdata.revision, "f".repeat(40)),
+        repoPolicy.tesseract.tessdata,
+      ),
+    /has not been reviewed/,
+  );
+});
+
+test("Artistic-2.0 packages retain exact Standard Version source", () => {
+  const sources = buildArtisticSourceSpecs(repoLock, repoPolicy.artisticPackages);
+  assert.equal(sources.length, 5);
+  for (const source of sources) {
+    assert.match(source.url, /^https:\/\/registry\.npmjs\.org\/[^/]+\/-\/[^/]+\.tgz$/);
+    assert.match(source.reason, /Standard Version source/);
+  }
+
+  const changed = structuredClone(repoLock);
+  changed.packages["node_modules/editions"].version = "99.0.0";
+  assert.throws(
+    () => buildArtisticSourceSpecs(changed, repoPolicy.artisticPackages),
+    /have not been reviewed/,
+  );
+});
+
+test("every reviewed source hash is referenced by the release manifest", () => {
+  const expected = buildComplianceSourceSpecs(
+    nativeVersions,
+    repoLock,
+    repoPolicy,
+    "win32",
+  ).map(({ id }) => id);
+  assert.deepEqual(
+    new Set(Object.keys(repoPolicy.sourceMaterials)),
+    new Set(expected),
+  );
 });
 
 test("native source manifest covers dependencies, build scripts, and patches", () => {
@@ -214,11 +301,8 @@ test("platform Sharp/libvips packages use the reviewed LGPL text", () => {
 });
 
 test("the lockfile is registry-portable and install scripts are reviewed", async () => {
-  const lock = JSON.parse(
-    await readFile(path.join(repoRoot, "package-lock.json"), "utf8"),
-  );
-  assert.doesNotThrow(() => assertPortableLockfileRegistries(lock));
-  assert.doesNotThrow(() => assertReviewedInstallScripts(lock, repoManifest));
+  assert.doesNotThrow(() => assertPortableLockfileRegistries(repoLock));
+  assert.doesNotThrow(() => assertReviewedInstallScripts(repoLock, repoManifest));
 
   const internal = {
     packages: {
@@ -582,6 +666,8 @@ test("source and release instructions remain compliance-preserving", async () =>
   assert.match(releasing, /not working-tree\s+files/i);
   assert.match(releasing, /SHA-256 values for `install\.ps1` and `install\.sh`/i);
   assert.match(releasing, /complete, version-matched\s+compliance bundle/i);
+  assert.match(releasing, /Tesseract\.js-core/);
+  assert.match(instructions, /Tesseract WebAssembly component notices/);
   assert.match(releasing, /Never silently replace an asset or move a release tag/i);
   assert.match(
     windowsWorkflow,

--- a/scripts/review-compliance-sources.mjs
+++ b/scripts/review-compliance-sources.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+/**
+ * Proposes SHA-256 values for newly reviewed compliance materials.
+ *
+ * The release path never bootstraps trust: `compliance:prepare` accepts only
+ * hashes already committed to the policy. This separate reviewer utility
+ * retrieves the exact pinned inputs and prints policy entries for inspection;
+ * it never edits the policy.
+ */
+import { execFile } from "node:child_process";
+import { createWriteStream, existsSync, readFileSync, statSync } from "node:fs";
+import { mkdir, rename, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import {
+  buildComplianceSourceSpecs,
+  buildStaticRemoteMaterialSpecs,
+  deterministicGitConfigArgs,
+  hasExpectedFileHeader,
+  sha256File,
+} from "./compliance.mjs";
+
+const execFileAsync = promisify(execFile);
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const reviewDir = path.join(rootDir, ".compliance-cache", "review");
+const reviewGitDir = path.join(tmpdir(), "skill-recorder-compliance-review-git");
+
+function parseArguments(argv) {
+  const options = { all: false, versions: null };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--all") options.all = true;
+    else if (argument === "--versions") options.versions = argv[(index += 1)];
+    else throw new Error(`Unknown argument ${argument}.`);
+  }
+  return options;
+}
+
+function loadNativeVersions(lock, versionsFile) {
+  if (versionsFile) return JSON.parse(readFileSync(path.resolve(versionsFile), "utf8"));
+  const candidates = Object.keys(lock.packages ?? {})
+    .filter((lockPath) => /^node_modules\/@img\/sharp-/.test(lockPath))
+    .map((lockPath) => path.join(rootDir, ...lockPath.split("/"), "versions.json"))
+    .filter(existsSync);
+  if (candidates.length === 0) {
+    throw new Error("No installed Sharp payload exposes versions.json; run npm ci first.");
+  }
+  const versions = candidates.map((file) => JSON.parse(readFileSync(file, "utf8")));
+  const canonical = JSON.stringify(versions[0]);
+  if (versions.some((value) => JSON.stringify(value) !== canonical)) {
+    throw new Error("Installed Sharp payloads disagree about embedded component versions.");
+  }
+  return versions[0];
+}
+
+function hasReviewedHash(hashes, id) {
+  return /^[a-f0-9]{64}$/.test(hashes?.[id] ?? "");
+}
+
+async function download(url, target) {
+  const temporary = `${target}.partial`;
+  let lastError;
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    await rm(temporary, { force: true });
+    try {
+      const response = await fetch(url, {
+        redirect: "follow",
+        headers: {
+          accept: "application/octet-stream, text/plain;q=0.9, */*;q=0.8",
+          "user-agent":
+            "Mozilla/5.0 (compatible; SkillRecorderCompliance/1.0; " +
+            "+https://github.com/microsoft/skill-recorder)",
+        },
+      });
+      if (!response.ok || !response.body) {
+        throw new Error(`HTTP ${response.status} ${response.statusText}`);
+      }
+      await pipeline(Readable.fromWeb(response.body), createWriteStream(temporary));
+      if (statSync(temporary).size < 100) throw new Error("response was unexpectedly short");
+      await rename(temporary, target);
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt < 3) await new Promise((resolve) => setTimeout(resolve, attempt * 1_000));
+    }
+  }
+  throw new Error(`Failed to download ${url}: ${lastError?.message ?? "unknown error"}`);
+}
+
+async function runGit(args, cwd) {
+  const { stdout } = await execFileAsync("git", args, {
+    cwd,
+    windowsHide: true,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  return stdout.trim();
+}
+
+async function gitArchive(spec, target) {
+  const safeId = spec.id.replaceAll(/[^A-Za-z0-9._-]/g, "_");
+  const repository = path.join(reviewGitDir, `${safeId}-${process.pid}`);
+  await rm(repository, { recursive: true, force: true });
+  await mkdir(repository, { recursive: true });
+  try {
+    await runGit(["init", "--quiet"], repository);
+    await runGit(
+      ["fetch", "--depth=1", "--no-tags", "--quiet", spec.gitRepository, spec.gitRevision],
+      repository,
+    );
+    const resolved = await runGit(["rev-parse", "FETCH_HEAD"], repository);
+    if (resolved !== spec.gitRevision) {
+      throw new Error(`Fetched ${spec.id} revision ${resolved}; expected ${spec.gitRevision}.`);
+    }
+    await runGit(
+      [
+        ...deterministicGitConfigArgs,
+        "archive",
+        "--format=tar",
+        `--prefix=${spec.archivePrefix}`,
+        `--output=${target}`,
+        "FETCH_HEAD",
+      ],
+      repository,
+    );
+  } finally {
+    await rm(repository, { recursive: true, force: true });
+  }
+}
+
+async function mapLimit(items, limit, worker) {
+  const results = new Array(items.length);
+  let next = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, async () => {
+      for (;;) {
+        const index = next;
+        next += 1;
+        if (index >= items.length) return;
+        results[index] = await worker(items[index]);
+      }
+    }),
+  );
+  return results;
+}
+
+async function reviewSources(specs, policy, all) {
+  const pending = specs.filter(({ id }) => all || !hasReviewedHash(policy.sourceMaterials, id));
+  return mapLimit(pending, 4, async (spec) => {
+    const target = path.join(reviewDir, "sources", spec.fileName);
+    await mkdir(path.dirname(target), { recursive: true });
+    await rm(target, { force: true });
+    if (spec.gitRepository) await gitArchive(spec, target);
+    else await download(spec.url, target);
+    if (!(await hasExpectedFileHeader(spec.fileName, target))) {
+      throw new Error(`${spec.id} did not produce a valid source archive.`);
+    }
+    return { id: spec.id, sha256: await sha256File(target), url: spec.url };
+  });
+}
+
+async function reviewRemoteMaterials(specs, policy, all) {
+  const pending = specs.filter(({ id }) => all || !hasReviewedHash(policy.remoteMaterials, id));
+  return mapLimit(pending, 4, async (spec) => {
+    const target = path.join(reviewDir, "remote", spec.fileName);
+    await mkdir(path.dirname(target), { recursive: true });
+    await rm(target, { force: true });
+    await download(spec.url, target);
+    const content = readFileSync(target, "utf8");
+    if (!content.includes(spec.marker)) {
+      throw new Error(`${spec.id} does not contain expected marker "${spec.marker}".`);
+    }
+    return { id: spec.id, sha256: await sha256File(target), url: spec.url };
+  });
+}
+
+function printEntries(label, results) {
+  console.log(`\nProposed third_party/compliance-policy.json ${label} entries:\n`);
+  if (results.length === 0) {
+    console.log("    (none)");
+    return;
+  }
+  console.log(
+    results
+      .sort((a, b) => a.id.localeCompare(b.id))
+      .map(({ id, sha256 }) => `    ${JSON.stringify(id)}: ${JSON.stringify(sha256)}`)
+      .join(",\n"),
+  );
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2));
+  const policy = JSON.parse(
+    readFileSync(path.join(rootDir, "third_party", "compliance-policy.json"), "utf8"),
+  );
+  const lock = JSON.parse(readFileSync(path.join(rootDir, "package-lock.json"), "utf8"));
+  const nativeVersions = loadNativeVersions(lock, options.versions);
+  const sourceSpecs = buildComplianceSourceSpecs(
+    nativeVersions,
+    lock,
+    policy,
+    process.platform,
+  );
+  const [sources, remote] = await Promise.all([
+    reviewSources(sourceSpecs, policy, options.all),
+    reviewRemoteMaterials(buildStaticRemoteMaterialSpecs(policy), policy, options.all),
+  ]);
+  printEntries("sourceMaterials", sources);
+  printEntries("remoteMaterials", remote);
+}
+
+await main();

--- a/src/App.css
+++ b/src/App.css
@@ -323,7 +323,7 @@ button:focus-visible,
   flex-direction: column;
   gap: 10px;
   padding: 16px 18px 14px;
-  height: 100vh;
+  min-height: 100vh;
 }
 
 /* The signature: a physical record transport. */
@@ -455,11 +455,29 @@ button:focus-visible,
   display: grid;
   place-items: center;
   flex: none;
-  width: 42px;
-  border-left: 1px solid var(--line);
+  align-self: center;
+  width: 32px;
+  height: 32px;
+  margin-right: 2px;
+  border-radius: 8px;
   color: var(--muted);
   background: transparent;
   transition: color 0.15s ease, background 0.15s ease;
+}
+
+.narrate-switch-btn {
+  display: flex;
+  align-items: center;
+  flex: none;
+  align-self: center;
+  padding: 0 11px 0 2px;
+  background: transparent;
+  cursor: pointer;
+}
+
+.narrate-switch-btn:disabled {
+  cursor: default;
+  opacity: 0.9;
 }
 
 .narrate-settings-toggle:not(:disabled):hover,
@@ -1873,6 +1891,284 @@ button:focus-visible,
 
 .cloud-analysis-caution {
   color: var(--brand-ink);
+}
+
+/* On-device sensitive-detail review (pre-send gate) */
+.sensitive-review {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+  max-width: 640px;
+  margin: 0 auto;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  border-radius: 12px;
+  padding: 12px 14px;
+  color: var(--text);
+}
+
+.sensitive-review-bar {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.sensitive-review-icon {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  color: var(--text);
+}
+
+.sensitive-review-headline {
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.sensitive-review-toggle {
+  flex: none;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.sensitive-dismiss {
+  flex: none;
+  font-size: 12px;
+}
+
+.sensitive-review-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-top: 2px;
+  border-top: 1px solid var(--line);
+}
+
+.sensitive-scroll {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 300px;
+  overflow-y: auto;
+  padding-right: 2px;
+}
+
+.sensitive-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sensitive-item {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  border-radius: 9px;
+  padding: 9px 11px;
+}
+
+.sensitive-dot {
+  flex: none;
+  width: 8px;
+  height: 8px;
+  margin-top: 5px;
+  border-radius: 50%;
+  background: var(--muted);
+}
+
+.sensitive-dot.sev-high {
+  background: var(--rec);
+  box-shadow: 0 0 6px rgba(var(--rec-rgb), 0.5);
+}
+
+.sensitive-dot.sev-medium {
+  background: var(--warn);
+}
+
+.sensitive-item-body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sensitive-item-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.sensitive-label {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.sensitive-source {
+  font-size: 11px;
+  color: var(--muted);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 1px 8px;
+}
+
+.sensitive-count {
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.sensitive-snippet {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  line-height: 1.45;
+  color: var(--muted);
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+
+.sensitive-caveat {
+  margin: 0;
+  font-size: 11.5px;
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+/* --- Protection status badge (in the "what's recorded" HUD button) ---------
+   The Advanced-protection control moved into the "What's recorded" sheet; the
+   HUD keeps a compact, read-only badge so on/off/ready state stays visible and
+   the whole row opens the sheet to change it. */
+.privacy-note-badge {
+  flex: none;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  line-height: 1;
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.privacy-note-badge.is-off {
+  color: var(--faint);
+  background: var(--surface);
+  border-color: var(--line);
+}
+
+/* --- Advanced protection toggle (inside the "what's recorded" sheet) -------- */
+.sheet-advp {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 14px;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.sheet-advp.on {
+  border-color: rgba(var(--brand-rgb), 0.4);
+  background: var(--signal-dim);
+}
+
+.sheet-advp-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.sheet-advp-copy {
+  flex: 1;
+  min-width: 0;
+}
+
+.sheet-advp-copy h3 {
+  margin: 0;
+}
+
+.sheet-switch-btn {
+  flex: none;
+  display: flex;
+  align-items: center;
+  margin-top: 2px;
+  padding: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.sheet-switch-btn:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+
+.sheet-switch {
+  box-sizing: border-box;
+  width: 40px;
+  height: 24px;
+  border-radius: 999px;
+  background: var(--line-strong);
+  padding: 3px;
+  transition: background 0.15s ease;
+}
+
+.sheet-switch.on {
+  background: var(--brand);
+}
+
+.sheet-switch-knob {
+  display: block;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  transition: transform 0.15s ease;
+}
+
+.sheet-switch.on .sheet-switch-knob {
+  transform: translateX(16px);
+}
+
+.sheet-advp-status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 4px;
+  font-size: 11.5px;
+  color: var(--muted);
+}
+
+.sheet-advp-status.is-error {
+  color: var(--warn);
+}
+
+.sheet-advp-download {
+  flex: none;
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--brand-ink);
+  background: transparent;
+  padding: 2px 4px;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.record-cta.danger {
+  background: var(--rec);
+  box-shadow: 0 2px 12px -3px rgba(var(--rec-rgb), 0.45);
+}
+
+.record-cta.danger:not(:disabled):hover {
+  filter: brightness(1.06);
+  box-shadow: 0 3px 16px -3px rgba(var(--rec-rgb), 0.55);
 }
 
 .voice-card {

--- a/src/Library.tsx
+++ b/src/Library.tsx
@@ -6,6 +6,7 @@ import type {
   AutomationBuildProgress,
   CopilotSignInResult,
   NarrationStatus,
+  SensitiveReport,
   SessionSummary,
   SkillBuildProgress,
   SkillPlacement,
@@ -38,6 +39,7 @@ import {
 } from "./plan-edit";
 import { formatBytes, formatDur, formatWhen, shortLabel } from "./format";
 import { skillPlacementModel, skillTargetFor } from "./skill-placement";
+import { SensitiveReview } from "./SensitiveReview";
 
 export function Library() {
   const [sessions, setSessions] = useState<SessionSummary[]>([]);
@@ -478,6 +480,9 @@ function AnalysisWorkspace({
   const [analyzing, setAnalyzing] = useState(false);
   const [statusLine, setStatusLine] = useState("");
   const [error, setError] = useState<string | null>(null);
+  // Informational summary of what the on-device scan redacted before sending;
+  // set alongside a successful analysis, cleared at the start of the next run.
+  const [review, setReview] = useState<SensitiveReport | null>(null);
   const [editing, setEditing] = useState(false);
   const [draftTitle, setDraftTitle] = useState("");
   const [draftIntent, setDraftIntent] = useState("");
@@ -506,11 +511,17 @@ function AnalysisWorkspace({
 
   useEffect(() => {
     let live = true;
-    void window.skillRecorder.getAnalysis(sessionId).then((a) => {
+    void Promise.all([
+      window.skillRecorder.getAnalysis(sessionId),
+      window.skillRecorder.getSensitiveReport(sessionId),
+    ]).then(([a, r]) => {
       if (!live) return;
       setAnalysis(a);
       setSteps(a?.steps ?? []);
       stepsDirty.current = false;
+      // Rehydrate the redaction summary so it survives reopen (only when the session
+      // is actually analyzed — never surface a stale report on an un-analyzed one).
+      setReview(a ? r : null);
     });
     return () => {
       live = false;
@@ -554,23 +565,30 @@ function AnalysisWorkspace({
     });
   }, [sessionId]);
 
-  const run = useCallback(async () => {
-    canceled.current = false;
-    setEditing(false);
-    setDraftTitle("");
-    setDraftIntent("");
-    setAnalyzing(true);
-    setError(null);
-    setStatusLine("Starting…");
-    const res = await window.skillRecorder.analyze(sessionId);
-    if (res.ok && res.analysis) {
-      setAnalysis(res.analysis);
-      setSteps(res.analysis.steps);
-      stepsDirty.current = false;
-    } else if (!canceled.current) setError(res.error ?? "Analysis failed");
-    setAnalyzing(false);
-    void onChanged();
-  }, [sessionId, onChanged]);
+  const run = useCallback(
+    async () => {
+      canceled.current = false;
+      setEditing(false);
+      setDraftTitle("");
+      setDraftIntent("");
+      setReview(null);
+      setError(null);
+      setAnalyzing(true);
+      setStatusLine("Starting…");
+      const res = await window.skillRecorder.analyze(sessionId);
+      if (res.ok && res.analysis) {
+        setAnalysis(res.analysis);
+        setSteps(res.analysis.steps);
+        stepsDirty.current = false;
+        // Non-blocking: analysis already ran. If anything was redacted before it
+        // was sent, show an informational summary alongside the result.
+        setReview(res.review ?? null);
+      } else if (!canceled.current) setError(res.error ?? "Analysis failed");
+      setAnalyzing(false);
+      void onChanged();
+    },
+    [sessionId, onChanged],
+  );
 
   const cancel = useCallback(async () => {
     canceled.current = true;
@@ -699,19 +717,23 @@ function AnalysisWorkspace({
         {summary.processed && !analysis && !analyzing && (
           <div className="ws-empty">
             <p className="ws-empty-lead">See what you did in this recording, step by step.</p>
-            <button className="record-cta" onClick={run}>
+            <button className="record-cta" onClick={() => void run()}>
               Analyze recording
             </button>
             <details className="analyze-disclosure">
               <summary>What gets sent to GitHub Copilot</summary>
               <p>
-                Analyze sends the event timeline—including window and document titles, URLs,
-                and clipboard previews—plus extracted screen images, narration text, and other
-                content you provide to GitHub&apos;s cloud service for processing by GitHub Copilot.{" "}
+                When you choose Analyze, the event timeline (window and document titles, URLs, and
+                clipboard previews), plus screen images, narration text, and other content you
+                provide, are sent to GitHub&apos;s cloud service for processing by GitHub Copilot.{" "}
                 <span className="cloud-analysis-caution">
                   Do not analyze a recording that may contain passwords, access tokens, API keys,
                   credentials, secrets, or other sensitive or confidential information.
-                </span>
+                </span>{" "}
+                By default, before anything is sent, this computer hides sensitive details like
+                passwords, keys, emails, and card or ID numbers from the text and your screen
+                images. You can turn this off in What&apos;s recorded for more accurate analysis. It
+                can miss things, so it is a safety net, not a guarantee.
               </p>
             </details>
             {voicePending && (
@@ -722,6 +744,10 @@ function AnalysisWorkspace({
               </p>
             )}
           </div>
+        )}
+
+        {summary.processed && review && !analyzing && (
+          <SensitiveReview report={review} onDismiss={() => setReview(null)} />
         )}
 
         {analyzing && (

--- a/src/Recorder.tsx
+++ b/src/Recorder.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import type {
   DoctorReport,
   MicrophoneSettingsStatus,
   NarrationStatus,
   RecorderStatus,
+  SensitiveModelStatus,
 } from "../common/ipc";
 import {
   DEFAULT_NARRATION_LANGUAGE,
@@ -23,6 +24,26 @@ const IS_MAC = typeof navigator !== "undefined" && /Mac/i.test(navigator.userAge
 const TOGGLE_SHORTCUT = IS_MAC ? "⌘⇧R" : "Ctrl+Shift+R";
 type PrivacyReviewOrigin = "home" | "warning";
 
+/** The HUD fills the window (`height:100vh`), so its own box can't reveal how tall the
+ *  content actually is. Sum the in-flow children (skipping absolute/fixed overlays like
+ *  scrims, popovers and the privacy sheet) to get the natural content height the window
+ *  should shrink/grow to. */
+function measureHudHeight(hud: HTMLElement): number {
+  const style = getComputedStyle(hud);
+  const gap = parseFloat(style.rowGap || style.gap) || 0;
+  let total = (parseFloat(style.paddingTop) || 0) + (parseFloat(style.paddingBottom) || 0);
+  let inFlow = 0;
+  for (const child of Array.from(hud.children)) {
+    if (!(child instanceof HTMLElement)) continue;
+    const cs = getComputedStyle(child);
+    if (cs.position === "absolute" || cs.position === "fixed" || cs.display === "none") continue;
+    total += child.getBoundingClientRect().height;
+    inFlow += 1;
+  }
+  if (inFlow > 1) total += gap * (inFlow - 1);
+  return Math.ceil(total);
+}
+
 export function Recorder() {
   const [status, setStatus] = useState<RecorderStatus | null>(null);
   const [doctor, setDoctor] = useState<DoctorReport | null>(null);
@@ -36,12 +57,15 @@ export function Recorder() {
   const [showNarrationSettings, setShowNarrationSettings] = useState(false);
   const [narrationLanguage, setSelectedNarrationLanguage] =
     useState<NarrationLanguage>(DEFAULT_NARRATION_LANGUAGE);
+  const [sensitive, setSensitive] = useState<SensitiveModelStatus | null>(null);
+  const [advancedPending, setAdvancedPending] = useState(false);
   const [microphonePending, setMicrophonePending] = useState(false);
   const [microphoneActionError, setMicrophoneActionError] = useState<string | null>(null);
   const [elapsed, setElapsed] = useState(0);
   const [sessionCount, setSessionCount] = useState(0);
   const [pendingCount, setPendingCount] = useState(0);
   const narrationSettingsRef = useRef<HTMLElement>(null);
+  const hudRef = useRef<HTMLDivElement>(null);
 
   const refreshCount = useCallback(async () => {
     const list = await window.skillRecorder.listSessions();
@@ -59,15 +83,18 @@ export function Recorder() {
     void window.skillRecorder.doctor().then(setDoctor);
     void window.skillRecorder.narrationStatus().then(setNarrationStatus);
     void window.skillRecorder.microphoneSettings().then(setMicrophoneSettings);
+    void window.skillRecorder.sensitiveModelStatus().then(setSensitive);
     void refreshCount();
     const offRecorder = window.skillRecorder.onStatusChanged(applyRecorderStatus);
     const offNarration = window.skillRecorder.onNarrationStatusChanged(setNarrationStatus);
     const offMicrophones =
       window.skillRecorder.onMicrophoneSettingsChanged(setMicrophoneSettings);
+    const offSensitive = window.skillRecorder.onSensitiveModelStatusChanged(setSensitive);
     return () => {
       offRecorder();
       offNarration();
       offMicrophones();
+      offSensitive();
     };
   }, [applyRecorderStatus, refreshCount]);
 
@@ -93,9 +120,12 @@ export function Recorder() {
   const justDiscarded = !recording && status?.lastFinish?.outcome === "discarded";
   const narrate = microphoneSettings?.narrationEnabled ?? false;
   const narrationLanguageName = narrationLanguageLabel(narrationLanguage);
+  const advancedOn = sensitive?.enabled ?? true;
 
   useEffect(() => {
-    if (recording) setShowNarrationSettings(false);
+    if (recording) {
+      setShowNarrationSettings(false);
+    }
   }, [recording]);
 
   useEffect(() => {
@@ -115,6 +145,40 @@ export function Recorder() {
       window.removeEventListener("mousedown", onMouseDown);
     };
   }, [showNarrationSettings]);
+
+  // Keep the fixed-width HUD window sized to its content: no dead space in short
+  // states, no clipping when the doctor reveals an extra model row. Observers catch
+  // both row add/remove (MutationObserver) and reflow/size changes (ResizeObserver).
+  useLayoutEffect(() => {
+    const hud = hudRef.current;
+    if (!hud) return;
+    let frame = 0;
+    const report = () => {
+      frame = 0;
+      window.skillRecorder.fitRecorderHeight?.(measureHudHeight(hud));
+    };
+    const schedule = () => {
+      if (frame) return;
+      frame = requestAnimationFrame(report);
+    };
+    const ro = new ResizeObserver(schedule);
+    const observeChildren = () => {
+      ro.disconnect();
+      for (const child of Array.from(hud.children)) ro.observe(child);
+    };
+    const mo = new MutationObserver(() => {
+      observeChildren();
+      schedule();
+    });
+    observeChildren();
+    mo.observe(hud, { childList: true });
+    schedule();
+    return () => {
+      if (frame) cancelAnimationFrame(frame);
+      ro.disconnect();
+      mo.disconnect();
+    };
+  }, []);
 
   // Refresh the library count whenever a recording finishes.
   useEffect(() => {
@@ -230,8 +294,26 @@ export function Recorder() {
     if (!res.ok) window.alert(res.error ?? "Could not download the voice transcription model.");
   }, []);
 
+  const toggleAdvanced = useCallback(async () => {
+    if (!sensitive) return;
+    const next = !sensitive.enabled;
+    setAdvancedPending(true);
+    setSensitive((s) => (s ? { ...s, enabled: next } : s)); // optimistic; real state follows
+    const res = await window.skillRecorder.setAdvancedProtection(next);
+    if (!res.ok) {
+      void window.skillRecorder.sensitiveModelStatus().then(setSensitive);
+      window.alert(res.error ?? "Could not update advanced protection.");
+    }
+    setAdvancedPending(false);
+  }, [sensitive]);
+
+  const downloadSensitiveModels = useCallback(async () => {
+    const res = await window.skillRecorder.downloadSensitiveModels();
+    if (!res.ok) window.alert(res.error ?? "Could not download the protection models.");
+  }, []);
+
   return (
-    <div className="hud">
+    <div className="hud" ref={hudRef}>
       <div className="transport">
         <button
           className={`record ${recording ? "on" : ""}`}
@@ -311,9 +393,6 @@ export function Recorder() {
                         : "Explain out loud (optional)"}
               </span>
             </span>
-            <span className={`narrate-switch ${narrate ? "on" : ""}`} aria-hidden>
-              <span className="narrate-knob" />
-            </span>
           </button>
           <button
             className={`narrate-settings-toggle ${showNarrationSettings ? "open" : ""}`}
@@ -333,6 +412,23 @@ export function Recorder() {
                 d="M19.43 12.98c.04-.32.07-.65.07-.98s-.03-.66-.07-.98l2.11-1.65a.5.5 0 0 0 .12-.64l-2-3.46a.5.5 0 0 0-.6-.22l-2.49 1a7.2 7.2 0 0 0-1.69-.98l-.38-2.65A.5.5 0 0 0 14 2h-4a.5.5 0 0 0-.5.42l-.38 2.65c-.61.25-1.17.58-1.69.98l-2.49-1a.5.5 0 0 0-.6.22l-2 3.46a.5.5 0 0 0 .12.64l2.11 1.65a7.7 7.7 0 0 0 0 1.96l-2.11 1.65a.5.5 0 0 0-.12.64l2 3.46a.5.5 0 0 0 .6.22l2.49-1c.52.4 1.08.73 1.69.98l.38 2.65A.5.5 0 0 0 10 22h4a.5.5 0 0 0 .5-.42l.38-2.65c.61-.25 1.17-.58 1.69-.98l2.49 1a.5.5 0 0 0 .6-.22l2-3.46a.5.5 0 0 0-.12-.64zM12 15.5a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7Z"
               />
             </svg>
+          </button>
+          <button
+            type="button"
+            className="narrate-switch-btn"
+            aria-hidden
+            tabIndex={-1}
+            disabled={
+              !microphoneSettings ||
+              microphonePending ||
+              recording ||
+              transitioning
+            }
+            onClick={() => void toggleNarration()}
+          >
+            <span className={`narrate-switch ${narrate ? "on" : ""}`}>
+              <span className="narrate-knob" />
+            </span>
           </button>
         </div>
 
@@ -437,6 +533,9 @@ export function Recorder() {
           <span className="privacy-note-title">Records your screen and activity</span>
           <span className="privacy-note-sub">See exactly what's captured</span>
         </span>
+        {!advancedOn ? (
+          <span className="privacy-note-badge is-off">Protection off</span>
+        ) : null}
         <span className="privacy-note-chevron" aria-hidden>
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
             <path
@@ -518,11 +617,18 @@ export function Recorder() {
             status={doctor.copilotCli.ok ? "good" : "bad"}
             note={doctor.copilotCli.ok ? "found" : "missing"}
           />
-          {narrationStatus && (
+          {narrate && narrationStatus && (
             <VoiceModelRow
               status={narrationStatus}
               recording={recording}
               onDownload={downloadNarrationModel}
+            />
+          )}
+          {sensitive && (
+            <SensitiveModelRow
+              status={sensitive}
+              recording={recording}
+              onDownload={downloadSensitiveModels}
             />
           )}
         </div>
@@ -542,6 +648,10 @@ export function Recorder() {
         <WhatsRecorded
           onClose={closePrivacyReview}
           onReviewed={() => void completePrivacyReview()}
+          sensitive={sensitive}
+          advancedPending={advancedPending}
+          onToggleAdvanced={() => void toggleAdvanced()}
+          onDownload={downloadSensitiveModels}
         />
       )}
     </div>
@@ -593,7 +703,7 @@ function VoiceModelRow({
     return <Row label="voice transcription" status="warn" note="preparing" />;
   }
   if (status.model === "ready") {
-    return <Row label="voice transcription" status="good" note="offline · multilingual" />;
+    return <Row label="voice transcription" status="good" note="on-device · multilingual" />;
   }
   return (
     <Row
@@ -609,6 +719,37 @@ function VoiceModelRow({
         disabled: recording,
         onClick: onDownload,
       }}
+    />
+  );
+}
+
+/** Single doctor row for the opt-out Advanced-protection model, shown while enabled.
+ *  Goes red whenever the on-device screen-text model isn't downloaded, with one
+ *  action that fetches it. */
+function SensitiveModelRow({
+  status,
+  recording,
+  onDownload,
+}: {
+  status: SensitiveModelStatus;
+  recording: boolean;
+  onDownload: () => void;
+}) {
+  if (!status.enabled) return null;
+  if (status.ocr === "downloading") {
+    const note = status.progress == null ? "downloading" : `${Math.round(status.progress)}%`;
+    return <Row label="advanced protection" status="warn" note={note} />;
+  }
+  if (status.ocr === "ready") {
+    return <Row label="advanced protection" status="good" note="on-device · multilingual" />;
+  }
+  const failed = status.ocr === "error";
+  return (
+    <Row
+      label="advanced protection"
+      status="bad"
+      note={failed ? "download failed" : "not downloaded"}
+      action={{ label: failed ? "retry" : "download", disabled: recording, onClick: onDownload }}
     />
   );
 }

--- a/src/SensitiveReview.tsx
+++ b/src/SensitiveReview.tsx
@@ -1,0 +1,137 @@
+import { useState } from "react";
+
+import type { SensitiveFinding, SensitiveReport } from "../common/ipc";
+import { sourceLabel } from "../common/sensitive";
+
+const SEVERITY_LABEL: Record<SensitiveFinding["severity"], string> = {
+  high: "High risk",
+  medium: "Possibly sensitive",
+  low: "Low confidence",
+};
+
+function headline(report: SensitiveReport): string {
+  const t = report.totalFindings;
+  const regions = report.images?.regionsBlurred ?? 0;
+  const details = `${t} sensitive ${t === 1 ? "detail" : "details"}`;
+  const areas = `${regions} on-screen ${regions === 1 ? "area" : "areas"}`;
+  if (t > 0 && regions > 0) return `Hid ${details} and blurred ${areas} before sending`;
+  if (t > 0) return `Hid ${details} before sending`;
+  if (regions > 0) return `Blurred ${areas} in screen images before sending`;
+  return "Checked for sensitive details before sending";
+}
+
+/**
+ * Informational, non-blocking result of the on-device pre-send scan. Collapsed to a
+ * single indication line by default (a shield + what was hidden); the details are
+ * behind a "Review" disclosure so the summary never crowds the analysis. Everything
+ * shown is masked / counted upstream in the scanner, so this component never sees a
+ * raw secret and image regions are reported as counts only. The user can dismiss it.
+ */
+export function SensitiveReview({
+  report,
+  onDismiss,
+}: {
+  report: SensitiveReport;
+  onDismiss: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const regions = report.images?.regionsBlurred ?? 0;
+  const frames = report.images?.framesBlurred ?? 0;
+  const hasDetails = report.findings.length > 0 || regions > 0;
+
+  return (
+    <section className="sensitive-review" role="status" aria-live="polite">
+      <div className="sensitive-review-bar">
+        <svg
+          className="sensitive-review-icon"
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M8 1.75 3 3.6v3.7c0 3.05 2.13 5.26 5 6.65 2.87-1.39 5-3.6 5-6.65V3.6L8 1.75Z"
+            stroke="currentColor"
+            strokeWidth="1.2"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M5.75 8.05 7.3 9.6l3.05-3.35"
+            stroke="currentColor"
+            strokeWidth="1.2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+        <p className="sensitive-review-headline">{headline(report)}</p>
+        {hasDetails && (
+          <button
+            className="sensitive-review-toggle linky"
+            aria-expanded={open}
+            onClick={() => setOpen((v) => !v)}
+          >
+            {open ? "Hide" : "Review"}
+          </button>
+        )}
+        <button className="sensitive-dismiss linky" onClick={onDismiss} aria-label="Dismiss">
+          Dismiss
+        </button>
+      </div>
+
+      {open && (
+        <div className="sensitive-review-body">
+          <div className="sensitive-scroll">
+            {report.findings.length > 0 && (
+              <ul className="sensitive-list">
+                {report.findings.map((f, i) => (
+                  <li key={`${f.source}-${f.label}-${i}`} className="sensitive-item">
+                    <span
+                      className={`sensitive-dot sev-${f.severity}`}
+                      title={SEVERITY_LABEL[f.severity]}
+                      aria-hidden="true"
+                    />
+                    <div className="sensitive-item-body">
+                      <div className="sensitive-item-head">
+                        <span className="sensitive-label">{f.label}</span>
+                        <span className="sensitive-source">{sourceLabel(f.source)}</span>
+                        {f.occurrences > 1 && (
+                          <span className="sensitive-count">×{f.occurrences}</span>
+                        )}
+                      </div>
+                      <code className="sensitive-snippet">{f.snippet}</code>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {regions > 0 && (
+              <div className="sensitive-item">
+                <span className="sensitive-dot sev-high" aria-hidden="true" />
+                <div className="sensitive-item-body">
+                  <div className="sensitive-item-head">
+                    <span className="sensitive-label">Blurred on-screen details</span>
+                    <span className="sensitive-source">Screen images</span>
+                  </div>
+                  <span className="sensitive-snippet">
+                    {regions === 1 ? "1 area" : `${regions} areas`} covered across{" "}
+                    {frames === 1 ? "1 image" : `${frames} images`}. The on-screen text is not kept,
+                    so it can&apos;t be listed here.
+                  </span>
+                </div>
+              </div>
+            )}
+          </div>
+
+          <p className="sensitive-caveat">
+            This ran on your computer and hid these before anything was sent to GitHub Copilot. It
+            covers secrets and personal details in the text that is sent (window titles, URLs,
+            clipboard, terminal commands, notes, and voice) and in your screen images. It is on by
+            default; you can turn it off in What&apos;s recorded.
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/WhatsRecorded.tsx
+++ b/src/WhatsRecorded.tsx
@@ -1,16 +1,47 @@
 import { useEffect, useRef } from "react";
 
+import type { SensitiveModelStatus } from "../common/ipc";
+
+/** Human-readable status for the on-device protection model shown in the sheet. */
+function protectionModelNote(status: SensitiveModelStatus | null): string {
+  if (!status) return "Checking…";
+  switch (status.ocr) {
+    case "ready":
+      return "On-device model ready";
+    case "downloading":
+      return status.progress == null
+        ? "Setting up the on-device model…"
+        : `Setting up the on-device model… ${Math.round(status.progress)}%`;
+    case "error":
+      return "Couldn't set up the model";
+    default:
+      return "On-device model not set up yet";
+  }
+}
+
 /**
  * Plain-language disclosure of what the recorder captures, where it is stored,
  * and what leaves the machine on analysis. Every claim here is grounded in the
  * actual collectors and describer behavior, so it must be kept in sync with them.
+ *
+ * Also home to the Advanced-protection opt-out toggle: protection is on by default,
+ * and this sheet is where the user reviews what it does and turns it off if they
+ * don't want on-device screen-image scanning.
  */
 export function WhatsRecorded({
   onClose,
   onReviewed,
+  sensitive,
+  advancedPending,
+  onToggleAdvanced,
+  onDownload,
 }: {
   onClose: () => void;
   onReviewed: () => void;
+  sensitive: SensitiveModelStatus | null;
+  advancedPending: boolean;
+  onToggleAdvanced: () => void;
+  onDownload: () => void;
 }) {
   const sheetRef = useRef<HTMLDivElement>(null);
 
@@ -22,6 +53,11 @@ export function WhatsRecorded({
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [onClose]);
+
+  const advancedOn = sensitive?.enabled ?? true;
+  const showModelError = advancedOn && sensitive?.ocr === "error";
+  const showDownloadAction =
+    advancedOn && (sensitive?.ocr === "error" || sensitive?.ocr === "missing");
 
   return (
     <div className="sheet-backdrop" onClick={onClose}>
@@ -95,7 +131,7 @@ export function WhatsRecorded({
               timeline.
             </li>
             <li>
-              The recording can be turned into text on this computer using an offline model. The
+              The recording can be turned into text on this computer using an on-device model. The
               transcript stays in the language you select from Whisper's 99 supported choices. The
               first transcription needs a one-time ~252 MB download that you choose when to start.
             </li>
@@ -116,11 +152,71 @@ export function WhatsRecorded({
           <ul>
             <li>Nothing leaves your computer while you record.</li>
             <li>
-              When you choose Analyze, the event timeline—including window and document titles,
-              URLs, and clipboard previews—plus extracted screen images and narration text (if
-              recorded) are sent to GitHub&apos;s cloud service and processed by GitHub Copilot.
+              When you choose Analyze, the event timeline (window and document titles, URLs, and
+              clipboard previews), plus screen images and narration text if recorded, are sent to
+              GitHub&apos;s cloud service and processed by GitHub Copilot.
+            </li>
+            <li>
+              By default, before anything is sent, this computer hides sensitive details like
+              passwords, keys, emails, and card or ID numbers from that text and from your screen
+              images. You can turn this off below.
             </li>
           </ul>
+        </section>
+
+        <section className={`sheet-block sheet-advp ${advancedOn ? "on" : ""}`}>
+          <div className="sheet-advp-head">
+            <div className="sheet-advp-copy">
+              <h3>Advanced protection</h3>
+              <p className="sheet-note">
+                On by default. Before your recording is analyzed, it checks the text and your screen
+                images on this computer and hides sensitive details. Turn it off to send everything
+                as recorded.
+              </p>
+            </div>
+            <button
+              type="button"
+              className="sheet-switch-btn"
+              role="switch"
+              aria-checked={advancedOn}
+              aria-busy={advancedPending}
+              aria-label="Advanced protection"
+              disabled={advancedPending}
+              onClick={onToggleAdvanced}
+            >
+              <span className={`sheet-switch ${advancedOn ? "on" : ""}`} aria-hidden>
+                <span className="sheet-switch-knob" />
+              </span>
+            </button>
+          </div>
+          {advancedOn && (
+            <>
+              <ul>
+                <li>
+                  It hides sensitive details like passwords, keys, emails, and card or ID numbers,
+                  both in the text that is sent (including narration) and in your screen images.
+                </li>
+                <li>
+                  Turning it off sends your recording as recorded. That can make the analysis more
+                  accurate, but nothing is hidden, so only do it when the recording has nothing
+                  sensitive.
+                </li>
+                <li>It all runs on this computer.</li>
+              </ul>
+              <div className={`sheet-advp-status ${showModelError ? "is-error" : ""}`}>
+                <span className="sheet-advp-model">{protectionModelNote(sensitive)}</span>
+                {showDownloadAction && (
+                  <button type="button" className="sheet-advp-download" onClick={onDownload}>
+                    {sensitive?.ocr === "error" ? "Retry" : "Set up now"}
+                  </button>
+                )}
+              </div>
+              <p className="sheet-caution">
+                No method is 100% effective. It can miss details or mask the wrong ones. Treat it as
+                a safety net, not a guarantee, and still avoid capturing anything secret.
+              </p>
+            </>
+          )}
         </section>
 
         <section className="sheet-block">

--- a/third_party/compliance-policy.json
+++ b/third_party/compliance-policy.json
@@ -22,12 +22,43 @@
   "sharpLibvips": {
     "version": "1.2.4"
   },
+  "secretlint": "13.0.4",
+  "artisticPackages": {
+    "binaryextensions": "6.11.0",
+    "editions": "6.22.0",
+    "istextorbinary": "9.5.0",
+    "textextensions": "6.11.0",
+    "version-range": "4.15.0"
+  },
+  "tesseract": {
+    "jsVersion": "7.0.0",
+    "coreVersion": "7.0.0",
+    "sourceRevisions": {
+      "core": "acffef2b66eb44a31df297e11d905f4b39001068",
+      "giflib": "fa37672085ce4b3d62c51627ab3c8cf2dda8009a",
+      "leptonica": "4af068b56a9674da915debea4ed7e1b9885b17e8",
+      "libjpeg": "6c0fcb8ddee365e7abc4d332662b06900612e923",
+      "libpng": "a37d4836519517bdce6cb9d956092321eca3e73b",
+      "libtiff": "b51bb157123264e26d34c09cc673d213aea61fc7",
+      "libwebp": "20ef03ee351d4ff03fc5ff3ec4804a879d1b9d5c",
+      "openlibm": "ae2d91698508701c83cab83714d42a1146dccf85",
+      "tesseract": "2a9c1c49c360462733c386d2a44fcd22c4e21411",
+      "zlib": "21767c654d31d2dccdde4330529775c6c5fd5389"
+    },
+    "tessdata": {
+      "revision": "65727574dfcd264acbb0c3e07860e4e9e9b22185",
+      "files": {
+        "eng.traineddata": "7d4322bd2a7749724879683fc3912cb542f19906c83bcc1a52132556427170b2"
+      }
+    }
+  },
   "onnxruntime": {
     "1.24.3": "v1.24.3",
     "1.24.0-dev.20251116-b39e144322": "b39e144322",
     "1.26.0-dev.20260416-b7804b056c": "b7804b056c"
   },
   "remoteMaterials": {
+    "artistic-2.0": "bae466ac8d7100c304fe76632ccc627203a3897d3f7166f3cce00fb9df8c2074",
     "gpl-3.0": "8ceb4b9ee5adedde47b31e975c1d90c73ad27b6b165a1dcd80c7c545eb65b903",
     "lgpl-2.1": "a9bdde5616ecdd1e980b44f360600ee8783b1f99b8cc83a2beb163a0a390e861",
     "lgpl-3.0": "a853c2ffec17057872340eee242ae4d96cbf2b520ae27d903e1b2fef1a5f9d1c",
@@ -37,7 +68,17 @@
     "onnxruntime-1.24.3-license": "2f07c72751aed99790b8a4869cf2311df85a860b22ded05fa22803587a48922c",
     "onnxruntime-1.24.3-notices": "0e07b95f3a8d6230037707c5c4a2b554d12c4cb67369669ac255635528ffcee2",
     "onnxruntime-1.26.0-dev.20260416-b7804b056c-license": "2f07c72751aed99790b8a4869cf2311df85a860b22ded05fa22803587a48922c",
-    "onnxruntime-1.26.0-dev.20260416-b7804b056c-notices": "0e07b95f3a8d6230037707c5c4a2b554d12c4cb67369669ac255635528ffcee2"
+    "onnxruntime-1.26.0-dev.20260416-b7804b056c-notices": "0e07b95f3a8d6230037707c5c4a2b554d12c4cb67369669ac255635528ffcee2",
+    "tessdata-fast-license": "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30",
+    "tesseract-core-giflib-license": "0c9b7990ecdca88b676db232c226548ac408b279f550d424d996f0d83591dd8e",
+    "tesseract-core-leptonica-license": "87829abb5bbb00b55a107365da89e9a33f86c4250169e5a1e5588505be7d5806",
+    "tesseract-core-libjpeg-license": "c791da525733040e622ed257c7b096b8f5191b332604ead0c6bc2b54cbd8e0d1",
+    "tesseract-core-libpng-license": "33ba4e187d8b0c8d7ab2bc2e522bb095219e03089e9aa0122b4fb9eb2b7de82b",
+    "tesseract-core-libtiff-license": "fbd6fed7938541d2c809c0826225fc85e551fdbfa8732b10f0c87e0847acafd7",
+    "tesseract-core-libwebp-license": "5aec868f669e384a22372a4e8a1a6cd7d44c64cd451f960ca69cc170d1e13acf",
+    "tesseract-core-openlibm-license": "b1843fbf5b03f519a5f0a44fce751bdd1022ae7148614923f9d6293e17a18b17",
+    "tesseract-core-tesseract-license": "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30",
+    "tesseract-core-zlib-license": "fc2c3368901700f0acdeb1d8afeaca5923296768ec6824ecdf627aac396001fd"
   },
   "sourceMaterials": {
     "electron": "9fa9a84bc0ee0aab5ec7f46de991dc55904e634fb566a75bb3f93599c861c46a",
@@ -78,6 +119,21 @@
     "sharp-patch-glib-without-gregex": "b1f2930a11292e529de137c7eb723850e0cc0969b1a2b0358196389312acd272",
     "sharp-patch-highway": "6ce65c4a6e90a4293da81cd3e932e81fd7ac77f31058143241ca9b8dd085098c",
     "sharp-patch-libvips-heif": "59a547c12915bc2670c37ff88200ebe74fe70aacce6e20b7069157a0d6a098c8",
-    "sharp-patch-libvips-soversion": "256b7d6f8c973bb53b20cff5171c7117d6b35d3aa4e72d22cb906f4fe1e2c890"
+    "sharp-patch-libvips-soversion": "256b7d6f8c973bb53b20cff5171c7117d6b35d3aa4e72d22cb906f4fe1e2c890",
+    "npm-source-binaryextensions@6.11.0": "52904eaa521067a062c75c601b47eb055474298ade50d6509458cd3157eb01bd",
+    "npm-source-editions@6.22.0": "ad07726331c2c4ffe29ff4d6744dcbae664ec4693a1b73c54be1b6835a79272e",
+    "npm-source-istextorbinary@9.5.0": "9a37f144a9742a1d2bac9fb5abff38009406b3e0d4abf6ab5a8369b09c44ef1a",
+    "npm-source-textextensions@6.11.0": "76194efbd484b3ac3be4cdc0d649ba8b9c0e154a53062ac067348e469cc66c09",
+    "npm-source-version-range@4.15.0": "fe26fd34a2432f197b89833c8e1e2807b1a7bec17cd8a7fb27956bab251a6d1a",
+    "tesseract-js-core@7.0.0": "b1af71435fc45cd5d9f3f9342b28f2ba649de4661a0fb2933da727a5648be262",
+    "tesseract-core-giflib@fa37672085ce4b3d62c51627ab3c8cf2dda8009a": "99067b2e3f4bfc3b95770a56e9def1daac843ecb6be5480cb776757b606ac076",
+    "tesseract-core-leptonica@4af068b56a9674da915debea4ed7e1b9885b17e8": "f889351f7df174ae9c15f27784b106310a1356d9152537543a334df08fd92961",
+    "tesseract-core-libjpeg@6c0fcb8ddee365e7abc4d332662b06900612e923": "79b3dc9496f015a5562f9170aabd0526b3efc5b5b8f71d9379c54d4d882a6099",
+    "tesseract-core-libpng@a37d4836519517bdce6cb9d956092321eca3e73b": "2429c23e583db954e5f8e8b92638a118bb8902f4d993ecfe0ce34b8afd05f507",
+    "tesseract-core-libtiff@b51bb157123264e26d34c09cc673d213aea61fc7": "e1e754ed88de9370637aecf75f36e31d77adccf6c0fab441816895dc92975a12",
+    "tesseract-core-libwebp@20ef03ee351d4ff03fc5ff3ec4804a879d1b9d5c": "397362f82d42c5577705979557f08d611d86e07abcaeeb66b78629df587f1df7",
+    "tesseract-core-openlibm@ae2d91698508701c83cab83714d42a1146dccf85": "7994b52a180357322559cafb745f03c5c1ee8f2f38c28bad1e224ce2a0221d7f",
+    "tesseract-core-tesseract@2a9c1c49c360462733c386d2a44fcd22c4e21411": "e021944185ecb88c2f003e706b5c416e7bef6074d4d8be39f6c98fe0695b24a8",
+    "tesseract-core-zlib@21767c654d31d2dccdde4330529775c6c5fd5389": "f1cdebb848d8110eba6773a481fd92cd34104f4b27deac5f7cf59b445a05f857"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -70,6 +70,7 @@ export default defineConfig({
                 "sharp",
                 "@huggingface/transformers",
                 "onnxruntime-node",
+                "tesseract.js",
               ],
             },
           },


### PR DESCRIPTION
## ⛔ DO NOT MERGE — work-in-progress checkpoint

Opened to **capture in-progress work** on on-device sensitive-detail detection + redaction so we can pick it up later. This branch **does not typecheck** and is not runnable as-is (see *Current state*). It is a design + partial-implementation snapshot, not a reviewable change.

## Goal
Detect and **auto-redact** sensitive/problematic details (secrets, PII, names) on-device *before* Skill Recorder sends captured session data to GitHub Copilot on **Analyze**. Fully local, MIT-compatible, and **non-blocking** — Analyze never stops; flagged values are redacted in the outgoing text and reported as "Redacted N details".

## Design (locked)
Three detection layers → one non-blocking redactor:
1. **secretlint** (`@secretlint/core` + preset-recommend + pattern rule) — provider secrets, **always on**. AWS ID scan enabled (`enableIDScanRule: true`); JWTs via a custom pattern rule.
2. **In-repo regex** (`common/sensitive.ts`) — structured PII: email, credit-card (Luhn), SSN, phone. **Always on**, renderer-safe.
3. **`Xenova/bert-base-NER`** (transformers.js, dtype `q8` → `model_quantized.onnx`) — person/location/org. **Opt-in "Advanced protection"** toggle that downloads the model; never blocks Analyze (`getPipelineForScan()` returns null until cached).

Overlapping matches collapse via `resolveOverlaps` by rank (secrets 90 > structured-PII 40–55 > NER 30). UI report masks values (`maskValue`, 2+2 reveal); outgoing text is redacted with non-revealing `••••`.

## 🚧 Why this is paused — architectural gap
`get_frames` sends screen **JPEGs inline** to the model, and **the LLM extracts data directly from those images** — we have **no OCR**. So text-only redaction can't touch a secret that's *visible on screen*: we'd mask the text while shipping a screenshot of the same secret. Text redaction still uniquely covers **voice narration**, **clipboard**, and **unsampled/off-screen** text, but the feature is **incomplete for on-screen secrets**.

**Decision needed before resuming** (any of):
- Add frame redaction: OCR each served frame (e.g. tesseract.js, Apache-2.0, offline) → run the *same* detectors → blur matched boxes with `sharp` (already a dep). ~1–3 s/frame CPU + one dep.
- Or scope the feature honestly to **text channels only** and strengthen the screenshot warning.
- Or drop it.

## Current state
- ✅ `common/sensitive.ts` — **rewritten to v2 core** (types + masking + structured-PII + generalized `resolveOverlaps`). Detectors verified by hand.
- ✅ secretlint API fully grounded (config shape, message→category mapping, dummy-key allowlist, AWS ID-scan gating).
- ✅ NER model grounded (`q8`, `enableCpuMemArena:false` required under Electron).
- ⚠️ **Downstream still v1** — `electron/sensitive/scanner.ts`, `common/sensitive.test.ts`, `electron/sensitive/scanner.test.ts`, `src/SensitiveReview.tsx`, and the IPC/UI wiring reference **removed v1 symbols** (`scanText`, `shannonEntropy`, `high-entropy`). **6 known `tsc` errors.**
- Test fixtures were rewritten to **runtime-constructed tokens** (no literal secrets) to satisfy push protection.

## Remaining work (bottom-up)
1. `electron/sensitive/`: `secretlint-config.ts`, `secrets.ts`, `ner-model.ts`, `ner.ts`, `model-manager.ts` (mirror `electron/narration/{whisper,manager}.ts`).
2. Rework `scanner.ts` → async `scanSession(id, nerPipeline?) → { report, values[] }` merging all 3 layers.
3. Thread a **redact seam** through `describer/{describer,tools}.ts` (wrap `get_timeline`/`get_events`/`get_narration`); remove the blocking gate in `common/ipc.ts` + `electron/ipc.ts`; wire `SensitiveModelManager` + sensitive IPC channels in `main.ts`/`preload.cjs`.
4. UI: non-blocking "Redacted N details" banner + "Advanced protection" opt-in toggle + status HUD (`SensitiveReview.tsx`, `Library.tsx`, `App.css`).
5. **Evals** (requested): `evals/sensitive/{corpus,score,run}.ts` — LLM-free detection precision/recall + redaction leak-check; NER cases gated on cache.
6. Compliance: `npm run compliance:prepare` for new MIT deps + THIRD-PARTY notices; attribute `bert-base-NER`. Review the secretlint transitive `npm audit` findings.
7. Resolve the **frames/OCR** decision above.

## How to resume
`common/sensitive.ts` is the source of truth for the v2 core. Implement the `electron/sensitive/*` modules, then flip the scanner + tests + UI off the v1 symbols until `npm run typecheck` and `npm test` pass. Detailed design notes and grounded API facts live in the session's plan doc.

_Co-authored-by: Copilot_