### PR TITLE
Fix 14 open Dependabot alerts (tar, adm-zip, fast-uri)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.2",
-        "adm-zip": "^0.5.18",
+        "adm-zip": "^0.6.0",
         "electron": "^43.0.0",
         "electron-builder": "^26.15.6",
         "typescript": "^7.0.0",
@@ -639,7 +639,7 @@
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
       "version": "1.2.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
       "integrity": "sha1-5jaB9FOalK+c0XJG7YiBc0OG+Mw=",
       "cpu": [
         "x64"
@@ -671,7 +671,7 @@
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
       "version": "1.2.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
       "integrity": "sha1-sbKIs2hks7zlRa2R+m2tzxpK0xg=",
       "cpu": [
         "arm64"
@@ -687,7 +687,7 @@
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
       "version": "1.2.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
       "integrity": "sha1-S4Ps8qgpBXIis4hIx7Ai57TQeqc=",
       "cpu": [
         "ppc64"
@@ -703,7 +703,7 @@
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
       "version": "1.2.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
       "integrity": "sha1-iAtGeACeWiCArxkjMrALCq+KSN4=",
       "cpu": [
         "riscv64"
@@ -719,7 +719,7 @@
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
       "version": "1.2.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
       "integrity": "sha1-dPNDyOEPrYIbOPdc7TBIiTncWew=",
       "cpu": [
         "s390x"
@@ -735,7 +735,7 @@
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
       "version": "1.2.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
       "integrity": "sha1-30GD6L2EEPfWG2aFmjXt6rClMc4=",
       "cpu": [
         "x64"
@@ -751,7 +751,7 @@
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
       "version": "1.2.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
       "integrity": "sha1-yNa0ghHfZxN1QQB+6NG3sfjKjgY=",
       "cpu": [
         "arm64"
@@ -767,7 +767,7 @@
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
       "version": "1.2.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
       "integrity": "sha1-vhHHW+5bCAy+4xoVOod5RI+Rn3U=",
       "cpu": [
         "x64"
@@ -783,7 +783,7 @@
     },
     "node_modules/@img/sharp-linux-arm": {
       "version": "0.34.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
       "integrity": "sha1-X7DDaV3RJSLTnD/3pryBZGF4Cg0=",
       "cpu": [
         "arm"
@@ -805,7 +805,7 @@
     },
     "node_modules/@img/sharp-linux-arm64": {
       "version": "0.34.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
       "integrity": "sha1-eqd2TvnAAfFeYQVG1C/OVpEXkMw=",
       "cpu": [
         "arm64"
@@ -827,7 +827,7 @@
     },
     "node_modules/@img/sharp-linux-ppc64": {
       "version": "0.34.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
       "integrity": "sha1-nCE6gVIKIMr2aXjz1MB0Vv8uCBM=",
       "cpu": [
         "ppc64"
@@ -849,7 +849,7 @@
     },
     "node_modules/@img/sharp-linux-riscv64": {
       "version": "0.34.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
       "integrity": "sha1-zdKBgndOrb4E9iZ1oWqrvMuDP2A=",
       "cpu": [
         "riscv64"
@@ -871,7 +871,7 @@
     },
     "node_modules/@img/sharp-linux-s390x": {
       "version": "0.34.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
       "integrity": "sha1-k+rGAbnzKbsnkX4OGQmMci1jDfc=",
       "cpu": [
         "s390x"
@@ -959,7 +959,7 @@
     },
     "node_modules/@img/sharp-wasm32": {
       "version": "0.34.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
       "integrity": "sha1-LxWAOqYm+MWd18nQu8dm8atSz6A=",
       "cpu": [
         "wasm32"
@@ -978,7 +978,7 @@
     },
     "node_modules/@img/sharp-win32-arm64": {
       "version": "0.34.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
       "integrity": "sha1-Nwbp46w1/d/ByH+U6Enxt1MHzgo=",
       "cpu": [
         "arm64"
@@ -1016,7 +1016,7 @@
     },
     "node_modules/@img/sharp-win32-x64": {
       "version": "0.34.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
       "integrity": "sha1-qB/7AOaSZ80KHWJurtuKhDCysvg=",
       "cpu": [
         "x64"
@@ -1133,7 +1133,7 @@
       "version": "4.0.1",
       "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
       "integrity": "sha1-LVmuOrSzj7QnC/oj0w+OLobH/jI=",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^7.0.4"
@@ -1471,16 +1471,6 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/@mapbox/node-pre-gyp/node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha1-Fb++U9LqtM9w8YqM1o6+Wzyx3s4=",
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@mapbox/node-pre-gyp/node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -1493,75 +1483,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/@mapbox/node-pre-gyp/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha1-PpeI/7kLaUpdDslEeaRbXYc4Ez0=",
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@mapbox/node-pre-gyp/node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha1-6Q00Zrogm5MkUVCKEc49NjIUWTE=",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@mapbox/node-pre-gyp/node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha1-e7o4TbOhUg0YycDlJRw0ROld2Uo=",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@mapbox/node-pre-gyp/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@mapbox/node-pre-gyp/node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha1-cXVJxUG8PCrxV1G+qUsd0GjUsDo=",
-      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -2622,12 +2543,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.18",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/adm-zip/-/adm-zip-0.5.18.tgz",
-      "integrity": "sha1-KDoF8r8eP9MV8PMc3im3puPBYZ0=",
+      "version": "0.6.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha1-u8XGwzN1XpZ6Bt2YdH9DHh1To88=",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -3343,16 +3264,6 @@
         "balanced-match": "^1.0.0"
       }
     },
-    "node_modules/cacache/node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha1-Fb++U9LqtM9w8YqM1o6+Wzyx3s4=",
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/cacache/node_modules/fs-minipass": {
       "version": "3.0.3",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fs-minipass/-/fs-minipass-3.0.3.tgz",
@@ -3409,101 +3320,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/cacache/node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha1-6Q00Zrogm5MkUVCKEc49NjIUWTE=",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/cacache/node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha1-e7o4TbOhUg0YycDlJRw0ROld2Uo=",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cacache/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cacache/node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha1-cXVJxUG8PCrxV1G+qUsd0GjUsDo=",
-      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cacache/node_modules/tar/node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha1-f1A2/b8SxjwWkZDL5BmchSJx+fs=",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/cacache/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha1-e7o4TbOhUg0YycDlJRw0ROld2Uo=",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cacache/node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha1-PpeI/7kLaUpdDslEeaRbXYc4Ez0=",
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -3570,7 +3386,7 @@
       "version": "3.0.0",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chownr/-/chownr-3.0.0.tgz",
       "integrity": "sha1-mFXmTs0kCpzEJnzopKpdJKHaFeQ=",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
@@ -4465,9 +4281,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha1-9pWkDwBqulBWMVc6ACHdshGUrRE=",
+      "version": "3.1.4",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha1-Oz2vnOaPQflW3wtQUTLAz86ex68=",
       "dev": true,
       "funding": [
         {
@@ -4603,32 +4419,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha1-f1A2/b8SxjwWkZDL5BmchSJx+fs=",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha1-e7o4TbOhUg0YycDlJRw0ROld2Uo=",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/fs.realpath": {
@@ -4803,16 +4593,6 @@
         "balanced-match": "^1.0.0"
       }
     },
-    "node_modules/get-windows/node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha1-Fb++U9LqtM9w8YqM1o6+Wzyx3s4=",
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/get-windows/node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/env-paths/-/env-paths-2.2.1.tgz",
@@ -4859,46 +4639,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/get-windows/node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha1-6Q00Zrogm5MkUVCKEc49NjIUWTE=",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/get-windows/node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha1-e7o4TbOhUg0YycDlJRw0ROld2Uo=",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/get-windows/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/get-windows/node_modules/node-gyp": {
@@ -4950,35 +4690,6 @@
       "optional": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/get-windows/node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha1-cXVJxUG8PCrxV1G+qUsd0GjUsDo=",
-      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/get-windows/node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha1-PpeI/7kLaUpdDslEeaRbXYc4Ez0=",
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/get-windows/node_modules/which": {
@@ -6219,7 +5930,7 @@
       "version": "3.1.0",
       "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minizlib/-/minizlib-3.1.0.tgz",
       "integrity": "sha1-atdsOo8QInybUdHJrI4wsn9aJRw=",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^7.1.2"
@@ -7592,10 +7303,10 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.20",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tar/-/tar-7.5.20.tgz",
-      "integrity": "sha1-N6ZaqRHL1phkAC4Uv4qSalVR4kA=",
-      "dev": true,
+      "version": "7.5.22",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha1-ppb5mBNucUh9w/hpqFu6LGeXG6k=",
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -7624,7 +7335,7 @@
       "version": "5.0.0",
       "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yallist/-/yallist-5.0.0.tgz",
       "integrity": "sha1-AOLeRDY57Q14/YfeDSdGn7z/tTM=",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -48,12 +48,17 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
-    "adm-zip": "^0.5.18",
+    "adm-zip": "^0.6.0",
     "electron": "^43.0.0",
     "electron-builder": "^26.15.6",
     "typescript": "^7.0.0",
     "vite": "^8.0.16",
     "vite-plugin-electron": "1.0.4"
+  },
+  "overrides": {
+    "adm-zip": "$adm-zip",
+    "fast-uri": "^3.1.4",
+    "tar": "^7.5.21"
   },
   "build": {
     "appId": "com.skillrecorder.app",


### PR DESCRIPTION
## What this does

Resolves 14 of the open Dependabot alerts by bumping a direct devDependency and adding npm `overrides` that force every transitive copy onto a patched release.

| Package | Alerts | Resolution |
|---|---|---|
| **tar** | 12 | `overrides` → all copies collapse to **7.5.22** |
| **adm-zip** | 1 | devDependency `^0.5.18` → `^0.6.0` (+ override) → **0.6.0** |
| **fast-uri** | 1 | `overrides` → **3.1.4** (under `ajv`) |

### Why overrides (not just a top-level bump)
The tar advisory ranges have **no lower bound** (e.g. `<= 7.5.18`, `< 7.5.7`). The real trigger was the nested **6.2.1** copies under `node-gyp` / `@mapbox/node-pre-gyp`, not the top-level `7.5.20`. A global `tar` override collapses every copy to `7.5.22`. This is safe: `@mapbox/node-pre-gyp@2` and `node-gyp@11+` already adopted `tar ^7` upstream, and the remaining 6.x consumers are all build-time/optional.

`adm-zip 0.6.0` is a security patch that keeps the `getEntry`/`getData`/`extractAllTo`/`extractEntryTo` API used by `scripts/compliance.mjs` and the onnxruntime-node install script.

## Verification
- `npm run typecheck` ✅
- `npm test` → 58/58 ✅
- `npm run compliance:licenses` ✅
- Confirmed no vulnerable copies remain in the lockfile.

## Not included — sharp (tracked separately)
The 15th alert (**sharp**, high) is intentionally **left out**. Bumping sharp to 0.35.x also bumps bundled **libvips 1.2.4 → 1.3.2**, which trips the deliberate license-compliance review gate (`third_party/compliance-policy.json` + `RELEASING.md`) and requires human review of the `THIRD-PARTY-NOTICES.md` and ~40 source-material hashes. Tracked in a separate issue so it gets the required review.

## Note
The `brace-expansion`/`minimatch` npm-audit noise is out of scope — those advisories are auto-dismissed in Dependabot and have no published patched 1.x/2.x release.