### PR TITLE
feat(recorder): add manual markers global shortcut and confirmation t…

### DIFF
--- a/common/ipc.ts
+++ b/common/ipc.ts
@@ -270,6 +270,16 @@ export interface MarkerResult {
   error?: string;
 }
 
+/**
+ * Broadcast whenever the global "add marker" shortcut fires during a recording,
+ * so any open window (chiefly the recording controls overlay) can show a
+ * lightweight, non-blocking confirmation. Firing is decided in the main
+ * process; this event does not itself request a marker be recorded.
+ */
+export interface MarkerAddedEvent {
+  timestamp: number;
+}
+
 export interface DeleteSessionResult {
   ok: boolean;
   error?: string;
@@ -361,6 +371,7 @@ export const IPC = {
   microphoneSettingsChanged: "microphone:settings-changed",
   status: "recorder:status",
   marker: "recorder:marker",
+  markerAdded: "recorder:marker-added",
   doctor: "doctor:check",
   copilotSignIn: "copilot:sign-in",
   statusChanged: "recorder:status-changed",
@@ -416,6 +427,8 @@ export interface SkillRecorderApi {
   ): () => void;
   status(): Promise<RecorderStatus>;
   marker(note: string): Promise<MarkerResult>;
+  /** Fires after a marker is recorded via the global "add marker" shortcut. */
+  onMarkerAdded(cb: (event: MarkerAddedEvent) => void): () => void;
   doctor(): Promise<DoctorReport>;
   /**
    * Open a terminal window running the bundled Copilot CLI's `login` command, so the

--- a/docs/future-features.md
+++ b/docs/future-features.md
@@ -4,35 +4,35 @@ Capabilities that are wired up in the codebase but deliberately not surfaced in
 the UI yet. Each entry is dormant, not dead: the backend path stays intact so the
 feature can be revived without re-plumbing it.
 
-## Manual markers ("Add marker")
+## Manual markers ("Add marker") — revived
 
-**Status:** backend retained, UI removed.
+**Status:** live, via a global hotkey instead of the old blocking button.
 
-A marker is a user-authored note captured mid-recording ("what are you doing
-right now?"). It was originally a HUD button that opened a blocking prompt.
+A marker is a precise "this instant matters" signal captured mid-recording. It
+was originally a HUD button that opened a blocking `window.prompt`; that version
+was removed in favor of voice narration, since narration already captures the
+same "stated intent" hands-free and continuously.
 
-**Why the button was removed:** voice narration supersedes it. Narration captures
-the same "stated intent" signal continuously, hands-free, and timestamped, without
-interrupting the task or letting a prompt dialog leak into the recorded frames. In
-practice the button was never used, and the describer already treated the "flick
-back to add a marker" moment as noise.
-
-**What still exists (the plumbing behind it):**
+**Current implementation:** `CommandOrControl+Shift+M` fires a marker at any
+point during a recording, from anywhere (not just while the app is focused),
+mirroring how `CommandOrControl+Shift+R` toggles recording. It never blocks or
+steals focus:
 
 | Layer | Location |
 | --- | --- |
-| Renderer bridge | `electron/preload.cjs` (`window.skillRecorder.marker`) |
-| IPC channel + result type | `common/ipc.ts`, `electron/ipc.ts` |
+| Global shortcut + dispatch | `electron/main.ts` (`addMarker`) |
 | Recorder handler | `electron/recorder/controller.ts` (`marker()`) |
+| Renderer bridge | `electron/preload.cjs` (`window.skillRecorder.marker`, `onMarkerAdded`) |
+| Confirmation broadcast | `common/ipc.ts` (`IPC.markerAdded`, `MarkerAddedEvent`) |
+| Toast UI | `src/RecordingControls.tsx` (`recording-marker-toast`), styled in `src/App.css` |
 | Event type + payload | `common/events.ts` (`EventType.Marker`, `MarkerPayload`) |
 | Correlation / bundling | `common/correlation.ts`, `common/bundle.ts` (`step.markers`) |
 | Description surfacing | `common/describe.ts`, describer + skillbuilder `tools.ts` |
 
-**What was removed:** the `Add marker` button and its `addMarker` handler in
-`src/Recorder.tsx`, plus the `.marker` styles in `src/App.css`.
+The confirmation is a small pill in the recording controls overlay that fades
+out on its own after ~2 seconds — no dialog, no interruption.
 
-**How to revive it well:** don't bring back the blocking `window.prompt`. Prefer a
-low-friction trigger that doesn't interrupt the recording, e.g. a global hotkey
-that flags the current moment (optionally with a quick inline note), so a marker
-becomes a precise "this instant matters" signal that complements the continuous
-narration transcript rather than duplicating it.
+**Not yet implemented:** an optional inline note. `marker(note)` already accepts
+free text, but the hotkey currently always records an empty note; typing a note
+into the toast without delaying the marker's timestamp (or introducing a second
+IPC round trip) needs a bit more design and is left as a follow-up.

--- a/electron/debug-bundle.test.ts
+++ b/electron/debug-bundle.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import AdmZip from "adm-zip";
 import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -32,9 +32,8 @@ test("writeDebugBundle zips the whole session under session/ next to debug-info.
       "output should start with the ZIP local-file-header magic",
     );
 
-    const names = execFileSync("unzip", ["-Z1", dest], { encoding: "utf8" })
-      .split(/\r?\n/)
-      .filter(Boolean);
+    const zip = new AdmZip(dest);
+    const names = zip.getEntries().map((entry) => entry.entryName);
     assert.ok(names.includes("debug-info.json"), "carries a top-level debug-info.json");
     assert.ok(
       names.includes("session/session.json"),

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -272,6 +272,23 @@ app.whenReady().then(async () => {
     log.warn("Global shortcut registration failed");
   }
 
+  // Marker capture: a low-friction, hands-free way to flag "this instant
+  // matters" without interrupting the recording. Deliberately not a dialog —
+  // see docs/future-features.md for why the old blocking "Add marker" button
+  // was removed and how a revival should behave.
+  const addMarker = () => {
+    if (recorder.state !== "recording") return;
+    const result = recorder.marker("");
+    if (!result.ok) {
+      log.warn("Marker capture failed:", result.error);
+      return;
+    }
+    broadcast(IPC.markerAdded, { timestamp: Date.now() });
+  };
+  if (!globalShortcut.register("CommandOrControl+Shift+M", addMarker)) {
+    log.warn("Marker shortcut registration failed");
+  }
+
   app.on("activate", () => {
     if (recorder.state === "recording") {
       showRecordingControls();

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -15,6 +15,7 @@ const IPC = {
   microphoneSettingsChanged: "microphone:settings-changed",
   status: "recorder:status",
   marker: "recorder:marker",
+  markerAdded: "recorder:marker-added",
   doctor: "doctor:check",
   copilotSignIn: "copilot:sign-in",
   statusChanged: "recorder:status-changed",
@@ -88,6 +89,11 @@ contextBridge.exposeInMainWorld("skillRecorder", {
   },
   status: () => ipcRenderer.invoke(IPC.status),
   marker: (note) => ipcRenderer.invoke(IPC.marker, note),
+  onMarkerAdded: (cb) => {
+    const listener = (_event, payload) => cb(payload);
+    ipcRenderer.on(IPC.markerAdded, listener);
+    return () => ipcRenderer.removeListener(IPC.markerAdded, listener);
+  },
   doctor: () => ipcRenderer.invoke(IPC.doctor),
   copilotSignIn: () => ipcRenderer.invoke(IPC.copilotSignIn),
   onStatusChanged: (cb) => {

--- a/electron/recorder/controller.test.ts
+++ b/electron/recorder/controller.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { access, mkdtemp, rm } from "node:fs/promises";
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -95,6 +95,43 @@ test("microphone toggles are serialized and finalized on save", async () => {
 
     await controller.whenProcessed();
     assert.equal(processed, 1);
+  });
+});
+
+test("marker is rejected when not recording and persisted when recording", async () => {
+  await withSessionsRoot(async (root) => {
+    const audio = new FakeAudioRecorder();
+    const controller = new RecorderController({
+      resolveConfig: () => ({ ...FULL_CAPTURE, video: false }),
+      buildCollectors: () => [],
+      createAudioRecorder: () => audio,
+      deleteSession: async () => undefined,
+    });
+
+    const rejected = controller.marker("too early");
+    assert.equal(rejected.ok, false);
+    assert.match(rejected.error ?? "", /not recording/i);
+
+    const started = await controller.start();
+    assert.equal(started.ok, true);
+
+    const accepted = controller.marker("checkpoint reached");
+    assert.equal(accepted.ok, true);
+
+    assert.equal((await controller.stop()).ok, true);
+
+    assert.ok(started.sessionId, "expected session ID");
+    const events = await readFile(
+      path.join(root, started.sessionId, "events.jsonl"),
+      "utf8",
+    );
+    const marker = events
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { type: string; payload: { note: string } })
+      .find((event) => event.type === "marker");
+    assert.ok(marker, "expected a persisted marker event");
+    assert.equal(marker?.payload.note, "checkpoint reached");
   });
 });
 

--- a/src/App.css
+++ b/src/App.css
@@ -1176,6 +1176,37 @@ button:focus-visible,
     white-space: nowrap;
   }
 
+  .recording-marker-toast {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    align-self: center;
+    padding: 7px 13px;
+    border: 1px solid var(--hud-line);
+    border-radius: 999px;
+    background: var(--hud-surface);
+    box-shadow: var(--hud-shadow);
+    color: var(--hud-text);
+    font-size: 11px;
+    font-weight: 600;
+    animation:
+      recording-confirm-in 0.15s ease-out,
+      recording-marker-toast-out 0.2s ease-in 2s forwards;
+    pointer-events: none;
+  }
+
+  .recording-marker-toast svg {
+    flex: none;
+    color: var(--hud-accent);
+  }
+
+  @keyframes recording-marker-toast-out {
+    to {
+      opacity: 0;
+      transform: translateY(-4px);
+    }
+  }
+
   .recording-microphone-options {
     display: flex;
     flex-direction: column;
@@ -1301,7 +1332,8 @@ button:focus-visible,
 @media (prefers-reduced-motion: reduce) {
   .recording-live-dot,
   .recording-discard-confirm,
-  .recording-microphone-menu {
+  .recording-microphone-menu,
+  .recording-marker-toast {
     animation: none;
   }
 }

--- a/src/RecordingControls.tsx
+++ b/src/RecordingControls.tsx
@@ -21,6 +21,7 @@ export function RecordingControls() {
   const [devicePending, setDevicePending] = useState(false);
   const [finishPending, setFinishPending] = useState<"done" | "discard" | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [markerToast, setMarkerToast] = useState(false);
   const keepRecordingRef = useRef<HTMLButtonElement>(null);
   const microphoneControlRef = useRef<HTMLDivElement>(null);
   const microphoneMenuRef = useRef<HTMLElement>(null);
@@ -36,6 +37,18 @@ export function RecordingControls() {
       offMicrophones();
     };
   }, []);
+
+  // Non-blocking confirmation for the global "add marker" shortcut. Never
+  // steals focus or pauses the recording — it just flashes and fades.
+  useEffect(() => {
+    return window.skillRecorder.onMarkerAdded(() => setMarkerToast(true));
+  }, []);
+
+  useEffect(() => {
+    if (!markerToast) return;
+    const timer = setTimeout(() => setMarkerToast(false), 2200);
+    return () => clearTimeout(timer);
+  }, [markerToast]);
 
   const recording = status?.state === "recording";
   const startedAt = status?.startedAt ?? null;
@@ -54,16 +67,17 @@ export function RecordingControls() {
     if (recording) return;
     if (confirmDiscard) setConfirmDiscard(false);
     if (showMicrophoneMenu) setShowMicrophoneMenu(false);
+    if (markerToast) setMarkerToast(false);
     setMicrophonePending(false);
     setDevicePending(false);
     setFinishPending(null);
-  }, [confirmDiscard, recording, showMicrophoneMenu]);
+  }, [confirmDiscard, markerToast, recording, showMicrophoneMenu]);
 
   useEffect(() => {
     void window.skillRecorder.setRecordingControlsExpanded(
-      confirmDiscard || showMicrophoneMenu,
+      confirmDiscard || showMicrophoneMenu || markerToast,
     );
-  }, [confirmDiscard, showMicrophoneMenu]);
+  }, [confirmDiscard, markerToast, showMicrophoneMenu]);
 
   useEffect(() => {
     if (!confirmDiscard) return;
@@ -244,6 +258,13 @@ export function RecordingControls() {
         </section>
       )}
 
+      {markerToast && !confirmDiscard && !showMicrophoneMenu && (
+        <section className="recording-marker-toast" role="status">
+          <MarkerIcon />
+          <span>Marker added</span>
+        </section>
+      )}
+
       {showMicrophoneMenu && (
         <section
           ref={microphoneMenuRef}
@@ -404,6 +425,19 @@ function ChevronIcon({ open }: { open: boolean }) {
         stroke="currentColor"
         strokeWidth="1.4"
         strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function MarkerIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden>
+      <path
+        d="M8 1.5 9.7 5l3.8.55-2.75 2.68.65 3.77L8 10.2l-3.4 1.8.65-3.77L2.5 5.55 6.3 5 8 1.5Z"
+        stroke="currentColor"
+        strokeWidth="1.3"
         strokeLinejoin="round"
       />
     </svg>


### PR DESCRIPTION
### Summary of Changes
- Revived manual markers via a global shortcut (`CommandOrControl+Shift+M`) without interrupting recordings or showing blocking dialogs.
- Added renderer bridge event `onMarkerAdded` in `electron/preload.cjs` and `common/ipc.ts`.
- Added a non-blocking confirmation toast in `src/RecordingControls.tsx` with fade-out keyframes in `src/App.css`.
- Updated `docs/future-features.md` to reflect the live status of the feature.
- Added unit test in `electron/recorder/controller.test.ts` verifying marker persistence during active recordings.

### Validation
- `npm run typecheck` - 0 errors
- `npm run typecheck:evals` - 0 errors
- `npm test` - 76 / 76 tests passing
- `npm run build` - Build succeeded cleanly
@microsoft-github-policy-service agree
