### PR TITLE
Fix portable source installation

### DIFF
--- a/.github/workflows/non-windows.yml
+++ b/.github/workflows/non-windows.yml
@@ -25,8 +25,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 24.19.0
           cache: npm
+
+      - name: Validate lockfile portability
+        run: npm run check:lockfile
 
       - name: Validate source installer guardrails
         run: |
@@ -58,7 +61,7 @@ jobs:
           test -x "$stub"
           plutil -lint "$plist"
 
-      - run: npm ci
+      - run: npm ci --ignore-scripts=false --dangerously-allow-all-scripts=false --strict-allow-scripts
       - run: npm run compliance:licenses
       - name: Verify platform license coverage
         run: |

--- a/.github/workflows/portable.yml
+++ b/.github/workflows/portable.yml
@@ -50,10 +50,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 24.19.0
           cache: npm
 
-      - run: npm ci
+      - name: Validate lockfile portability
+        run: npm run check:lockfile
+
+      - run: npm ci --ignore-scripts=false --dangerously-allow-all-scripts=false --strict-allow-scripts
 
       - name: Package portable app
         run: npm run ${{ matrix.build_script }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,18 +31,8 @@ jobs:
       - name: Validate source installer guardrails
         shell: pwsh
         run: |
-          $tokens = $null
-          $parseErrors = $null
           $path = (Resolve-Path "install.ps1").Path
-          [void][System.Management.Automation.Language.Parser]::ParseFile(
-            $path,
-            [ref]$tokens,
-            [ref]$parseErrors
-          )
-          if ($parseErrors.Count -ne 0) {
-            $parseErrors | ForEach-Object { Write-Error $_.Message }
-            throw "install.ps1 contains PowerShell syntax errors"
-          }
+          & .\scripts\install-windows.test.ps1 -InstallerPath $path
           $beforeErrorPreference = $ErrorActionPreference
           $beforeProgressPreference = $ProgressPreference
           $env:SKILL_RECORDER_COMMIT = "master"
@@ -73,9 +63,12 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 24.19.0
           architecture: ${{ matrix.arch }}
           cache: npm
+
+      - name: Validate lockfile portability
+        run: npm run check:lockfile
 
       - name: Install native dependencies
         shell: pwsh
@@ -83,7 +76,7 @@ jobs:
           if ((node -p "process.arch") -ne "${{ matrix.arch }}") {
             throw "Expected Node ${{ matrix.arch }}"
           }
-          npm ci
+          npm ci --ignore-scripts=false --dangerously-allow-all-scripts=false --strict-allow-scripts
           node -e "require('sharp'); require('onnxruntime-node'); require('koffi')"
           if (Select-String -Path package-lock.json -Pattern 'ffmpeg-static' -Quiet) {
             throw "ffmpeg-static remains in the lockfile"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,7 +3,8 @@
 Skill Recorder can run directly from an exact source revision on Windows, macOS,
 or Ubuntu. These methods do not download a prebuilt Skill Recorder application.
 Node.js, Electron, native dependencies, and the GitHub Copilot CLI are obtained
-directly from their publishers and assembled locally.
+from canonical upstreams or compatible configured registries and assembled
+locally.
 
 The generated build is for local execution only. Do not redistribute the build,
 `node_modules`, or downloaded runtimes. Release binaries must use the
@@ -46,8 +47,10 @@ The source installers:
    its archive against Node.js's `SHASUMS256.txt`. Windows additionally verifies
    the OpenJS Foundation Authenticode signature.
 4. Download only the exact source commit from GitHub Codeload.
-5. Run `npm ci`, install Electron from its official release endpoint, and confirm
-   Electron's official checksum manifest matches the reviewed compliance policy.
+5. Validate that the lockfile contains canonical npmjs URLs, run `npm ci` through
+   the user's configured registry or compatible mirror, install Electron from its
+   official release endpoint, and confirm Electron's official checksum manifest
+   matches the reviewed compliance policy.
 6. Run `npm run compliance:licenses` and fail if any installed platform package
    lacks reviewed legal material.
 7. Build locally, retain repository/dependency licenses, and record hashes for
@@ -161,8 +164,10 @@ installed revision.
 
 ## Manual developer setup
 
-Install native Node.js 24 from its official publisher. Download the exact commit
-archive rather than repository history.
+Install Node.js 24.19 or newer within the Node.js 24 release line from its
+official publisher. This supplies npm 11.17 or newer, which is required to
+enforce the reviewed dependency lifecycle-script policy. Download the exact
+commit archive rather than repository history.
 
 ### Windows PowerShell
 
@@ -173,8 +178,9 @@ $parent = Join-Path $PWD "skill-recorder-source"
 Invoke-WebRequest "https://codeload.github.com/microsoft/skill-recorder/zip/$commit" -OutFile $archive -UseBasicParsing
 Expand-Archive $archive $parent
 Set-Location (Join-Path $parent "skill-recorder-$commit")
-npm ci
-node node_modules\electron\install.js
+npm run check:lockfile
+npm ci --ignore-scripts=false --dangerously-allow-all-scripts=false --strict-allow-scripts
+npm run electron:install-reviewed
 npm run compliance:licenses
 npm run build
 npm start
@@ -190,8 +196,9 @@ curl -fsSL "https://codeload.github.com/microsoft/skill-recorder/tar.gz/$commit"
 mkdir "$source_dir"
 tar -xzf "$archive" --strip-components=1 -C "$source_dir"
 cd "$source_dir"
-npm ci
-node node_modules/electron/install.js
+npm run check:lockfile
+npm ci --ignore-scripts=false --dangerously-allow-all-scripts=false --strict-allow-scripts
+npm run electron:install-reviewed
 npm run compliance:licenses
 npm run build
 npm start
@@ -217,26 +224,32 @@ curl -fsSL "https://codeload.github.com/microsoft/skill-recorder/tar.gz/$commit"
 mkdir "$source_dir"
 tar -xzf "$archive" --strip-components=1 -C "$source_dir"
 cd "$source_dir"
-npm ci
-node node_modules/electron/install.js
+npm run check:lockfile
+npm ci --ignore-scripts=false --dangerously-allow-all-scripts=false --strict-allow-scripts
+npm run electron:install-reviewed
 npm run compliance:licenses
 npm run build
 npm start
 ```
 
-For hot-reload development, run `npm run dev` after `npm ci` and
-`npm run compliance:licenses`.
+For hot-reload development, run `npm run dev` after the validated install
+sequence above and `npm run compliance:licenses`.
 
-The lockfile pins the dependency graph. Use `npm ci`, not `npm install`, and do
-not regenerate the lockfile during installation. Keep the entire checkout,
-`.compliance`, and dependency legal files.
+The lockfile pins the dependency graph with canonical `registry.npmjs.org` URLs
+and integrity hashes. npm may map those URLs to a configured compatible
+corporate registry. Use `npm ci`, not `npm install`, and do not regenerate the
+lockfile during installation. Keep the entire checkout, `.compliance`, and
+dependency legal files.
 
 ## Licensing boundary
 
 The source channels distribute this repository's MIT-licensed source. The
-user's package manager obtains Electron, Sharp/libvips, ONNX Runtime, the
-unmodified GitHub Copilot CLI, and other dependencies from their publishers.
-The local build is not a redistributable application package.
+user's package manager obtains Sharp/libvips, ONNX Runtime, the unmodified
+GitHub Copilot CLI, and other npm dependencies through its configured registry;
+the installer obtains the reviewed Electron runtime from GitHub. Canonical
+registry URLs and integrity hashes keep the lockfile portable across direct
+npmjs access and compatible corporate mirrors. The local build is not a
+redistributable application package.
 
 Each platform's compliance check retains:
 

--- a/README.md
+++ b/README.md
@@ -152,10 +152,13 @@ the inspect-first alternative, manual developer setup, updates, uninstallation,
 and the licensing boundary between local source builds and redistributable
 packages.
 
-For development after checking out an exact revision:
+Requires **Node.js 24.19+ within the Node.js 24 release line**, including
+**npm 11.17+**. For development after checking out an exact revision:
 
 ```bash
-npm ci
+npm run check:lockfile
+npm ci --ignore-scripts=false --dangerously-allow-all-scripts=false --strict-allow-scripts
+npm run electron:install-reviewed
 npm run compliance:licenses
 npm run dev
 ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -35,7 +35,9 @@ below before updating any compliance policy hash.
 Run:
 
 ```sh
-npm ci
+npm run fix:lockfile-registry
+npm run check:lockfile
+npm ci --ignore-scripts=false --dangerously-allow-all-scripts=false --strict-allow-scripts
 npm run compliance:licenses
 ```
 
@@ -45,8 +47,15 @@ Inspect:
 - `.compliance/THIRD-PARTY-LICENSES.txt`;
 - `THIRD-PARTY-NOTICES.md`;
 - changes to `package-lock.json`;
+- the exact-version approvals and explicit denials in `package.json#allowScripts`;
 - every new or changed image, font, model, native library, executable, and
   copied source file.
+
+The committed lockfile must use canonical `registry.npmjs.org` resolved URLs.
+Microsoft contributors may fetch through a configured internal mirror, but
+internal feed URLs must never be committed. Review every new dependency install
+script before adding an exact-version approval; explicitly deny scripts that
+are not required.
 
 The compliance scripts intentionally reject unreviewed component versions and
 materials. Do not fix such a failure by blindly replacing a version or hash.

--- a/install.ps1
+++ b/install.ps1
@@ -121,6 +121,92 @@ function Remove-CachedDownload {
   }
 }
 
+function ConvertTo-ExtendedLengthPath {
+  param([Parameter(Mandatory)][string]$Path)
+
+  $fullPath = [IO.Path]::GetFullPath($Path)
+  if ($fullPath.StartsWith("\\?\")) {
+    return $fullPath
+  }
+  if ($fullPath.StartsWith("\\")) {
+    return "\\?\UNC\" + $fullPath.Substring(2)
+  }
+  return "\\?\" + $fullPath
+}
+
+function Move-DirectoryTree {
+  param(
+    [Parameter(Mandatory)][string]$Source,
+    [Parameter(Mandatory)][string]$Destination,
+    [ValidateRange(1, 20)][int]$MaxAttempts = 6,
+    [ValidateRange(0, 5000)][int]$RetryDelayMilliseconds = 250
+  )
+
+  $extendedSource = ConvertTo-ExtendedLengthPath -Path $Source
+  $extendedDestination = ConvertTo-ExtendedLengthPath -Path $Destination
+  if (-not [IO.Directory]::Exists($extendedSource)) {
+    throw "Directory to move does not exist: $Source"
+  }
+  if (
+    [IO.Directory]::Exists($extendedDestination) -or
+    [IO.File]::Exists($extendedDestination)
+  ) {
+    throw "Refusing to overwrite an existing path: $Destination"
+  }
+
+  for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+    try {
+      [IO.Directory]::Move($extendedSource, $extendedDestination)
+      return
+    } catch {
+      $exception = $_.Exception
+      $isIoFailure = (
+        $exception -is [IO.IOException] -or
+        $exception.InnerException -is [IO.IOException]
+      )
+      if (-not $isIoFailure -or $attempt -eq $MaxAttempts) {
+        throw
+      }
+      if (
+        -not [IO.Directory]::Exists($extendedSource) -or
+        [IO.Directory]::Exists($extendedDestination) -or
+        [IO.File]::Exists($extendedDestination)
+      ) {
+        throw
+      }
+      if ($attempt -eq 1) {
+        Write-Warning "The installation directory is temporarily locked; retrying the move."
+      }
+      Start-Sleep -Milliseconds ($RetryDelayMilliseconds * $attempt)
+    }
+  }
+}
+
+function Remove-DirectoryTree {
+  param([Parameter(Mandatory)][string]$Path)
+
+  $extendedPath = ConvertTo-ExtendedLengthPath -Path $Path
+  if (-not [IO.Directory]::Exists($extendedPath)) {
+    return
+  }
+
+  $attributes = [IO.File]::GetAttributes($extendedPath)
+  if (($attributes -band [IO.FileAttributes]::ReparsePoint) -eq 0) {
+    foreach ($entry in [IO.Directory]::EnumerateFileSystemEntries($extendedPath)) {
+      $entryAttributes = [IO.File]::GetAttributes($entry)
+      if (($entryAttributes -band [IO.FileAttributes]::Directory) -ne 0) {
+        Remove-DirectoryTree -Path $entry
+      } else {
+        [IO.File]::SetAttributes($entry, [IO.FileAttributes]::Normal)
+        [IO.File]::Delete($entry)
+      }
+    }
+  }
+
+  [IO.File]::SetAttributes($extendedPath, [IO.FileAttributes]::Normal)
+  [IO.Directory]::Delete($extendedPath, $false)
+}
+
 function Assert-ZipArchive {
   param([Parameter(Mandatory)][string]$Path)
 
@@ -282,6 +368,12 @@ function Assert-ReviewedElectronDistribution {
   if ($manifestHash -ne $reviewedHash) {
     throw "Electron's checksum manifest does not match the reviewed distribution hash."
   }
+
+  return [pscustomobject]@{
+    Version = [string]$electronPackage.version
+    ArchiveName = $archiveName
+    Sha256 = $reviewedHash
+  }
 }
 
 function Get-NodeRuntime {
@@ -352,7 +444,7 @@ function Get-NodeRuntime {
     Assert-RequiredPaths -Root $expandedDirectory -RelativePaths @("LICENSE", "npm.cmd")
 
     New-Item -ItemType Directory -Path $RuntimeRoot -Force | Out-Null
-    Move-Item -LiteralPath $expandedDirectory -Destination $runtimeDirectory
+    Move-DirectoryTree -Source $expandedDirectory -Destination $runtimeDirectory
     Remove-CachedDownload -CachePath $archivePath
   } else {
     Write-Step "Reusing the verified Node.js $version runtime already installed at $runtimeDirectory."
@@ -505,25 +597,15 @@ if (Test-Path -LiteralPath $sourceDirectory -PathType Container) {
       "THIRD-PARTY-NOTICES.md",
       "CONTRIBUTING.md",
       "package.json",
-      "package-lock.json"
+      "package-lock.json",
+      "scripts\check-lockfile-portability.mjs",
+      "scripts\install-reviewed-electron.mjs",
+      "scripts\run-reviewed-electron.mjs"
     )
 
-    Write-Step "Installing lockfile-pinned dependencies from their publishers."
     $environmentOverrides = [ordered]@{
       PATH = "$($runtime.Root);$env:PATH"
-      NPM_CONFIG_REGISTRY = "https://registry.npmjs.org/"
-      NPM_CONFIG_REPLACE_REGISTRY_HOST = "never"
-      NPM_CONFIG_PLATFORM = "win32"
-      NPM_CONFIG_ARCH = $architecture
-      ELECTRON_MIRROR = "https://github.com/electron/electron/releases/download/"
-      NPM_CONFIG_ELECTRON_MIRROR = "https://github.com/electron/electron/releases/download/"
-      ELECTRON_INSTALL_PLATFORM = "win32"
-      ELECTRON_INSTALL_ARCH = $architecture
-      ELECTRON_USE_REMOTE_CHECKSUMS = $null
-      NPM_CONFIG_ELECTRON_USE_REMOTE_CHECKSUMS = $null
-      ELECTRON_OVERRIDE_DIST_PATH = $null
-      ELECTRON_CUSTOM_DIR = $null
-      ELECTRON_CUSTOM_FILENAME = $null
+      NPM_CONFIG_ALLOW_SCRIPTS = $null
     }
     $originalEnvironment = @{}
     foreach ($entry in $environmentOverrides.GetEnumerator()) {
@@ -540,20 +622,62 @@ if (Test-Path -LiteralPath $sourceDirectory -PathType Container) {
 
     Push-Location $buildDirectory
     try {
+      $npmVersionOutput = @(& $runtime.Npm --version)
+      if ($LASTEXITCODE -ne 0 -or $npmVersionOutput.Count -eq 0) {
+        throw "Could not determine the bundled npm version."
+      }
+      $npmVersion = ([string]$npmVersionOutput[0]).Trim()
+
+      Write-Step "Validating portable dependency policy."
+      Invoke-CheckedCommand `
+        -FilePath $runtime.Node `
+        -Arguments @(
+          "scripts\check-lockfile-portability.mjs",
+          "--npm-version",
+          $npmVersion
+        ) `
+        -Description "lockfile portability validation"
+
+      Write-Step "Installing lockfile-pinned dependencies through the configured npm registry."
       Invoke-CheckedCommand `
         -FilePath $runtime.Npm `
-        -Arguments @("ci", "--no-audit", "--no-fund") `
+        -Arguments @(
+          "ci",
+          "--no-audit",
+          "--no-fund",
+          "--ignore-scripts=false",
+          "--dangerously-allow-all-scripts=false",
+          "--strict-allow-scripts"
+        ) `
         -Description "npm ci"
 
-      Assert-ReviewedElectronDistribution `
+      $electronDistribution = Assert-ReviewedElectronDistribution `
         -SourceDirectory $buildDirectory `
         -Architecture $architecture
 
       Write-Step "Downloading the checksummed Electron runtime from GitHub."
+      $electronArchive = Join-Path $cacheRoot $electronDistribution.ArchiveName
+      $null = Get-CachedDownload `
+        -Uri (
+          "https://github.com/electron/electron/releases/download/" +
+          "v$($electronDistribution.Version)/$($electronDistribution.ArchiveName)"
+        ) `
+        -CachePath $electronArchive `
+        -ExpectedSha256 $electronDistribution.Sha256
+      Assert-ZipArchive -Path $electronArchive
       Invoke-CheckedCommand `
         -FilePath $runtime.Node `
-        -Arguments @("node_modules\electron\install.js") `
-        -Description "Electron runtime download"
+        -Arguments @(
+          "scripts\install-reviewed-electron.mjs",
+          "--archive",
+          $electronArchive,
+          "--platform",
+          "win32",
+          "--arch",
+          $architecture
+        ) `
+        -Description "reviewed Electron runtime installation"
+      Remove-CachedDownload -CachePath $electronArchive
 
       Write-Step "Validating dependency licenses and notices."
       Invoke-CheckedCommand `
@@ -614,11 +738,13 @@ if (Test-Path -LiteralPath $sourceDirectory -PathType Container) {
     if (Test-Path -LiteralPath $sourceDirectory) {
       throw "Refusing to overwrite an existing source installation: $sourceDirectory"
     }
-    Move-Item -LiteralPath $buildDirectory -Destination $sourceDirectory
+    Move-DirectoryTree -Source $buildDirectory -Destination $sourceDirectory
     Remove-CachedDownload -CachePath $sourceArchive
   } finally {
-    if (Test-Path -LiteralPath $stagingDirectory) {
-      Remove-Item -LiteralPath $stagingDirectory -Recurse -Force
+    try {
+      Remove-DirectoryTree -Path $stagingDirectory
+    } catch {
+      Write-Warning "Could not remove temporary installation files at ${stagingDirectory}: $($_.Exception.Message)"
     }
   }
 }

--- a/install.sh
+++ b/install.sh
@@ -186,6 +186,9 @@ required_install_files() {
   local files="
 LICENSE
 THIRD-PARTY-NOTICES.md
+scripts/check-lockfile-portability.mjs
+scripts/install-reviewed-electron.mjs
+scripts/run-reviewed-electron.mjs
 third_party/compliance-policy.json
 node_modules/@github/copilot/LICENSE.md
 node_modules/$copilot_package/LICENSE.md
@@ -260,15 +263,21 @@ build_source_install() {
   tar -xzf "$archive" --strip-components=1 -C "$STAGING_DIR"
 
   cd "$STAGING_DIR"
-  export NPM_CONFIG_REGISTRY="https://registry.npmjs.org/"
   export NPM_CONFIG_CACHE="$INSTALL_ROOT/npm-cache"
-  export ELECTRON_MIRROR="https://github.com/electron/electron/releases/download/"
+  unset NPM_CONFIG_ALLOW_SCRIPTS npm_config_allow_scripts
 
-  info "Installing lockfile-pinned dependencies from their publishers."
-  "$NPM" ci --no-audit --no-fund
+  info "Validating portable dependency policy."
+  local npm_version
+  npm_version="$("$NPM" --version)" || die "Could not determine the bundled npm version."
+  "$NODE" "scripts/check-lockfile-portability.mjs" --npm-version "$npm_version"
 
-  info "Installing the reviewed Electron runtime."
-  "$NODE" "node_modules/electron/install.js"
+  info "Installing lockfile-pinned dependencies through the configured npm registry."
+  "$NPM" ci \
+    --no-audit \
+    --no-fund \
+    --ignore-scripts=false \
+    --dangerously-allow-all-scripts=false \
+    --strict-allow-scripts
 
   local policy_key="$PLATFORM-$ARCHITECTURE"
   local electron_version reviewed_hash
@@ -303,6 +312,19 @@ build_source_install() {
   )"
   [ "$bundled_hash" = "$reviewed_hash" ] ||
     die "Electron's installed checksum manifest differs from the reviewed compliance policy."
+
+  info "Downloading the checksummed Electron runtime from GitHub."
+  local electron_download="$WORK_DIR/$electron_archive"
+  download \
+    "https://github.com/electron/electron/releases/download/v${electron_version}/${electron_archive}" \
+    "$electron_download"
+  [ "$(sha256_file "$electron_download")" = "$reviewed_hash" ] ||
+    die "Electron archive SHA-256 does not match the reviewed distribution hash."
+  "$NODE" "scripts/install-reviewed-electron.mjs" \
+    --archive "$electron_download" \
+    --platform "$PLATFORM" \
+    --arch "$ARCHITECTURE"
+
   [ "$(cat node_modules/electron/dist/version)" = "$electron_version" ] ||
     die "The installed Electron runtime version is not $electron_version."
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,9 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@electron-internal/extract-zip": "1.0.4",
         "@electron/asar": "^3.4.1",
+        "@electron/get": "5.0.0",
         "@types/archiver": "^6.0.4",
         "@types/node": "^22.10.0",
         "@types/react": "^19.2.14",
@@ -32,13 +34,17 @@
         "vite": "^8.0.16",
         "vite-plugin-electron": "1.0.4"
       },
+      "engines": {
+        "node": ">=24.19.0 <25",
+        "npm": ">=11.17.0"
+      },
       "optionalDependencies": {
         "get-windows": "^9.3.0"
       }
     },
     "node_modules/@electron-internal/extract-zip": {
       "version": "1.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@electron-internal/extract-zip/-/extract-zip-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.4.tgz",
       "integrity": "sha1-ALLFy9Sf3AdNPr+N/vPHt7cutG0=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -48,7 +54,7 @@
     },
     "node_modules/@electron/asar": {
       "version": "3.4.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@electron/asar/-/asar-3.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
       "integrity": "sha1-TpGWpLVPuhjFbNjVysZ8W9xYgGU=",
       "dev": true,
       "license": "MIT",
@@ -66,14 +72,14 @@
     },
     "node_modules/@electron/asar/node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@electron/asar/node_modules/brace-expansion": {
       "version": "1.1.16",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
       "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
       "dev": true,
       "license": "MIT",
@@ -84,7 +90,7 @@
     },
     "node_modules/@electron/asar/node_modules/minimatch": {
       "version": "3.1.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
       "dev": true,
       "license": "ISC",
@@ -97,7 +103,7 @@
     },
     "node_modules/@electron/fuses": {
       "version": "1.8.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@electron/fuses/-/fuses-1.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@electron/fuses/-/fuses-1.8.0.tgz",
       "integrity": "sha1-rTTTzEcDsSWLg/aYmRcFLPwUkKA=",
       "dev": true,
       "license": "MIT",
@@ -112,7 +118,7 @@
     },
     "node_modules/@electron/fuses/node_modules/fs-extra": {
       "version": "9.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fs-extra/-/fs-extra-9.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha1-WVRGDHZKjaIJS6NVS/g55rmnyG0=",
       "dev": true,
       "license": "MIT",
@@ -128,7 +134,7 @@
     },
     "node_modules/@electron/get": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@electron/get/-/get-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
       "integrity": "sha1-PH7A4mSAzlGkh9VMihAjNGBTECE=",
       "dev": true,
       "license": "MIT",
@@ -149,7 +155,7 @@
     },
     "node_modules/@electron/notarize": {
       "version": "2.5.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@electron/notarize/-/notarize-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
       "integrity": "sha1-1NJTVq36Kd9Kdr1kqL00cjfNJR4=",
       "dev": true,
       "license": "MIT",
@@ -164,7 +170,7 @@
     },
     "node_modules/@electron/notarize/node_modules/fs-extra": {
       "version": "9.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fs-extra/-/fs-extra-9.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha1-WVRGDHZKjaIJS6NVS/g55rmnyG0=",
       "dev": true,
       "license": "MIT",
@@ -180,7 +186,7 @@
     },
     "node_modules/@electron/osx-sign": {
       "version": "1.3.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@electron/osx-sign/-/osx-sign-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.3.tgz",
       "integrity": "sha1-r3UVEEiDGNn3ZjaUr4WBlpDXVYM=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -202,7 +208,7 @@
     },
     "node_modules/@electron/osx-sign/node_modules/isbinaryfile": {
       "version": "4.0.10",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
       "integrity": "sha1-DFteMMJVei8G/r03tzIpRqruQrM=",
       "dev": true,
       "license": "MIT",
@@ -215,7 +221,7 @@
     },
     "node_modules/@electron/rebuild": {
       "version": "4.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@electron/rebuild/-/rebuild-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.2.0.tgz",
       "integrity": "sha1-7nQpqXE00T6ze39RfXN+AtHeqHc=",
       "dev": true,
       "license": "MIT",
@@ -236,7 +242,7 @@
     },
     "node_modules/@electron/universal": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@electron/universal/-/universal-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.3.tgz",
       "integrity": "sha1-FoDfbO2PEoyg/yTinCFl1B14s84=",
       "dev": true,
       "license": "MIT",
@@ -255,14 +261,14 @@
     },
     "node_modules/@electron/universal/node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
       "integrity": "sha1-C7oicf631Fiw0xrRNiWqpHVEMeI=",
       "dev": true,
       "license": "MIT",
@@ -272,7 +278,7 @@
     },
     "node_modules/@electron/universal/node_modules/fs-extra": {
       "version": "11.3.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fs-extra/-/fs-extra-11.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
       "integrity": "sha1-98uA6d9VDNHbb1N/pc3VaNPnDRA=",
       "dev": true,
       "license": "MIT",
@@ -287,7 +293,7 @@
     },
     "node_modules/@electron/universal/node_modules/minimatch": {
       "version": "9.0.9",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-9.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha1-mwy5/LeAh/b9fqur4lEcTT1gV04=",
       "dev": true,
       "license": "ISC",
@@ -303,7 +309,7 @@
     },
     "node_modules/@electron/windows-sign": {
       "version": "1.2.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
       "integrity": "sha1-jOqtUtXB6xhwL0gQPV87x8M4+p0=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -325,7 +331,7 @@
     },
     "node_modules/@electron/windows-sign/node_modules/fs-extra": {
       "version": "11.3.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fs-extra/-/fs-extra-11.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
       "integrity": "sha1-98uA6d9VDNHbb1N/pc3VaNPnDRA=",
       "dev": true,
       "license": "MIT",
@@ -377,7 +383,7 @@
     },
     "node_modules/@github/copilot": {
       "version": "1.0.71",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot/-/copilot-1.0.71.tgz",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.71.tgz",
       "integrity": "sha1-qfslXZyT7W6RLbxQauAFX+FGawU=",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
@@ -399,7 +405,7 @@
     },
     "node_modules/@github/copilot-darwin-arm64": {
       "version": "1.0.71",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.71.tgz",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.71.tgz",
       "integrity": "sha1-oJN6YmXMs8QSEDCpMZB+/bVoPh0=",
       "cpu": [
         "arm64"
@@ -415,7 +421,7 @@
     },
     "node_modules/@github/copilot-darwin-x64": {
       "version": "1.0.71",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.71.tgz",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.71.tgz",
       "integrity": "sha1-Z16zgpTufMUogjN4C4VHN8YcgfQ=",
       "cpu": [
         "x64"
@@ -431,7 +437,7 @@
     },
     "node_modules/@github/copilot-linux-arm64": {
       "version": "1.0.71",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.71.tgz",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.71.tgz",
       "integrity": "sha1-h+m9TgXvPg9fOdIX0Lb6/Ynl9XM=",
       "cpu": [
         "arm64"
@@ -447,7 +453,7 @@
     },
     "node_modules/@github/copilot-linux-x64": {
       "version": "1.0.71",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.71.tgz",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.71.tgz",
       "integrity": "sha1-9BwtUbwXXy+RrUtZRlbU2IdC85g=",
       "cpu": [
         "x64"
@@ -463,7 +469,7 @@
     },
     "node_modules/@github/copilot-linuxmusl-arm64": {
       "version": "1.0.71",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.71.tgz",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.71.tgz",
       "integrity": "sha1-lk7OeAX0J16RvB2Fo/FMLHFS15o=",
       "cpu": [
         "arm64"
@@ -479,7 +485,7 @@
     },
     "node_modules/@github/copilot-linuxmusl-x64": {
       "version": "1.0.71",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.71.tgz",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.71.tgz",
       "integrity": "sha1-ncPmnC+w4Ea3piz/f267CRcov/s=",
       "cpu": [
         "x64"
@@ -495,7 +501,7 @@
     },
     "node_modules/@github/copilot-sdk": {
       "version": "1.0.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-sdk/-/copilot-sdk-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-1.0.7.tgz",
       "integrity": "sha1-mOR4GgbFRX6DFwSXJgO9PAq4Ywk=",
       "license": "MIT",
       "dependencies": {
@@ -510,7 +516,7 @@
     },
     "node_modules/@github/copilot-win32-arm64": {
       "version": "1.0.71",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.71.tgz",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.71.tgz",
       "integrity": "sha1-ZFwwVoPGoWfToNyhk4rRFN9O4mE=",
       "cpu": [
         "arm64"
@@ -526,7 +532,7 @@
     },
     "node_modules/@github/copilot-win32-x64": {
       "version": "1.0.71",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.71.tgz",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.71.tgz",
       "integrity": "sha1-LzyWpWloTZhn0YrmZ4akGH7PYfA=",
       "cpu": [
         "x64"
@@ -542,7 +548,7 @@
     },
     "node_modules/@huggingface/jinja": {
       "version": "0.5.9",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@huggingface/jinja/-/jinja-0.5.9.tgz",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.9.tgz",
       "integrity": "sha1-KU90H6CYwrMXN4i0TKZRlYv/o20=",
       "license": "MIT",
       "engines": {
@@ -551,13 +557,13 @@
     },
     "node_modules/@huggingface/tokenizers": {
       "version": "0.1.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@huggingface/tokenizers/-/tokenizers-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@huggingface/tokenizers/-/tokenizers-0.1.3.tgz",
       "integrity": "sha1-0bsrJTdeVQyCbkxxUdX3ZKFKamk=",
       "license": "Apache-2.0"
     },
     "node_modules/@huggingface/transformers": {
       "version": "4.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@huggingface/transformers/-/transformers-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-4.2.0.tgz",
       "integrity": "sha1-WlNCoaFIxdKX7YOE0hzuGCT6sDE=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -570,7 +576,7 @@
     },
     "node_modules/@img/colour": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/colour/-/colour-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha1-sMLC+mYa33Xv/WtJZEl82AAQu50=",
       "license": "MIT",
       "engines": {
@@ -579,7 +585,7 @@
     },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.34.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
       "integrity": "sha1-bgcy3K3hJrZnCveqFwYLkmg16oY=",
       "cpu": [
         "arm64"
@@ -601,7 +607,7 @@
     },
     "node_modules/@img/sharp-darwin-x64": {
       "version": "0.34.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
       "integrity": "sha1-Gbwd1uum1alig0mLnJ9AEYDunHs=",
       "cpu": [
         "x64"
@@ -623,7 +629,7 @@
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
       "version": "1.2.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
       "integrity": "sha1-KJTAy4fUInbDiJlC6OLbUXpJLEM=",
       "cpu": [
         "arm64"
@@ -639,7 +645,7 @@
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
       "version": "1.2.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
       "integrity": "sha1-5jaB9FOalK+c0XJG7YiBc0OG+Mw=",
       "cpu": [
         "x64"
@@ -655,7 +661,7 @@
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
       "version": "1.2.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
       "integrity": "sha1-uSYN0evm+eO9vL3KydKsEl81hS0=",
       "cpu": [
         "arm"
@@ -671,7 +677,7 @@
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
       "version": "1.2.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
       "integrity": "sha1-sbKIs2hks7zlRa2R+m2tzxpK0xg=",
       "cpu": [
         "arm64"
@@ -687,7 +693,7 @@
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
       "version": "1.2.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
       "integrity": "sha1-S4Ps8qgpBXIis4hIx7Ai57TQeqc=",
       "cpu": [
         "ppc64"
@@ -703,7 +709,7 @@
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
       "version": "1.2.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
       "integrity": "sha1-iAtGeACeWiCArxkjMrALCq+KSN4=",
       "cpu": [
         "riscv64"
@@ -719,7 +725,7 @@
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
       "version": "1.2.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
       "integrity": "sha1-dPNDyOEPrYIbOPdc7TBIiTncWew=",
       "cpu": [
         "s390x"
@@ -735,7 +741,7 @@
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
       "version": "1.2.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
       "integrity": "sha1-30GD6L2EEPfWG2aFmjXt6rClMc4=",
       "cpu": [
         "x64"
@@ -751,7 +757,7 @@
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
       "version": "1.2.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
       "integrity": "sha1-yNa0ghHfZxN1QQB+6NG3sfjKjgY=",
       "cpu": [
         "arm64"
@@ -767,7 +773,7 @@
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
       "version": "1.2.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
       "integrity": "sha1-vhHHW+5bCAy+4xoVOod5RI+Rn3U=",
       "cpu": [
         "x64"
@@ -783,7 +789,7 @@
     },
     "node_modules/@img/sharp-linux-arm": {
       "version": "0.34.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
       "integrity": "sha1-X7DDaV3RJSLTnD/3pryBZGF4Cg0=",
       "cpu": [
         "arm"
@@ -805,7 +811,7 @@
     },
     "node_modules/@img/sharp-linux-arm64": {
       "version": "0.34.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
       "integrity": "sha1-eqd2TvnAAfFeYQVG1C/OVpEXkMw=",
       "cpu": [
         "arm64"
@@ -827,7 +833,7 @@
     },
     "node_modules/@img/sharp-linux-ppc64": {
       "version": "0.34.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
       "integrity": "sha1-nCE6gVIKIMr2aXjz1MB0Vv8uCBM=",
       "cpu": [
         "ppc64"
@@ -849,7 +855,7 @@
     },
     "node_modules/@img/sharp-linux-riscv64": {
       "version": "0.34.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
       "integrity": "sha1-zdKBgndOrb4E9iZ1oWqrvMuDP2A=",
       "cpu": [
         "riscv64"
@@ -871,7 +877,7 @@
     },
     "node_modules/@img/sharp-linux-s390x": {
       "version": "0.34.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
       "integrity": "sha1-k+rGAbnzKbsnkX4OGQmMci1jDfc=",
       "cpu": [
         "s390x"
@@ -893,7 +899,7 @@
     },
     "node_modules/@img/sharp-linux-x64": {
       "version": "0.34.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
       "integrity": "sha1-VavHzXVP/KUAK2wrcZq9/IRoGag=",
       "cpu": [
         "x64"
@@ -915,7 +921,7 @@
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
       "version": "0.34.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
       "integrity": "sha1-1lFe6XG7YvcwAaSCm52GWhG3cIY=",
       "cpu": [
         "arm64"
@@ -937,7 +943,7 @@
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
       "version": "0.34.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
       "integrity": "sha1-2Xl4rsfFIS+ZlxTy9bc2RX4S7p8=",
       "cpu": [
         "x64"
@@ -959,7 +965,7 @@
     },
     "node_modules/@img/sharp-wasm32": {
       "version": "0.34.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
       "integrity": "sha1-LxWAOqYm+MWd18nQu8dm8atSz6A=",
       "cpu": [
         "wasm32"
@@ -978,7 +984,7 @@
     },
     "node_modules/@img/sharp-win32-arm64": {
       "version": "0.34.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
       "integrity": "sha1-Nwbp46w1/d/ByH+U6Enxt1MHzgo=",
       "cpu": [
         "arm64"
@@ -997,7 +1003,7 @@
     },
     "node_modules/@img/sharp-win32-ia32": {
       "version": "0.34.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
       "integrity": "sha1-C3EWZZmwSeAy8IX7kmPgL05HiN4=",
       "cpu": [
         "ia32"
@@ -1016,7 +1022,7 @@
     },
     "node_modules/@img/sharp-win32-x64": {
       "version": "0.34.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
       "integrity": "sha1-qB/7AOaSZ80KHWJurtuKhDCysvg=",
       "cpu": [
         "x64"
@@ -1035,7 +1041,7 @@
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha1-s3Znt7wYHBaHgiWbq0JHT79StVA=",
       "license": "ISC",
       "dependencies": {
@@ -1052,7 +1058,7 @@
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
       "version": "6.2.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha1-YCFu6kZNhkWXzigyAAc4oFiWUME=",
       "license": "MIT",
       "engines": {
@@ -1064,7 +1070,7 @@
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
       "version": "6.2.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha1-wETV3MUhoHZBNHJZehrLHxA8QEE=",
       "license": "MIT",
       "engines": {
@@ -1076,13 +1082,13 @@
     },
     "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha1-hAyIA7DYBH9P8M+WMXazLU7z7XI=",
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha1-FPja7G2B5yIdKjV+Zoyrc728p5Q=",
       "license": "MIT",
       "dependencies": {
@@ -1099,7 +1105,7 @@
     },
     "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
       "version": "7.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha1-0iomlSKDamJ6+NBLXD/Sx/o+MuM=",
       "license": "MIT",
       "dependencies": {
@@ -1114,7 +1120,7 @@
     },
     "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
       "version": "8.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha1-VtwiNo7lcPrOG0mBmXXZuaXq0hQ=",
       "license": "MIT",
       "dependencies": {
@@ -1131,7 +1137,7 @@
     },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
       "integrity": "sha1-LVmuOrSzj7QnC/oj0w+OLobH/jI=",
       "dev": true,
       "license": "ISC",
@@ -1144,7 +1150,7 @@
     },
     "node_modules/@koromix/koffi-darwin-arm64": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.1.1.tgz",
       "integrity": "sha1-fuITEx+inH8+FrN2/mhZG/wAZhA=",
       "cpu": [
         "arm64"
@@ -1160,7 +1166,7 @@
     },
     "node_modules/@koromix/koffi-darwin-x64": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.1.1.tgz",
       "integrity": "sha1-CA9ptRZ6/UYIog2E/3QLHHu9fhg=",
       "cpu": [
         "x64"
@@ -1176,7 +1182,7 @@
     },
     "node_modules/@koromix/koffi-freebsd-arm64": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.1.1.tgz",
       "integrity": "sha1-eQyVDXxFOed3S+DlMN+n+0JrKUQ=",
       "cpu": [
         "arm64"
@@ -1192,7 +1198,7 @@
     },
     "node_modules/@koromix/koffi-freebsd-ia32": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.1.1.tgz",
       "integrity": "sha1-aopIhXLatDUaqd2goZPySUpxWik=",
       "cpu": [
         "ia32"
@@ -1208,7 +1214,7 @@
     },
     "node_modules/@koromix/koffi-freebsd-x64": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.1.1.tgz",
       "integrity": "sha1-jqyca0fWWnpb3SA6KxfKT1NhXTo=",
       "cpu": [
         "x64"
@@ -1224,7 +1230,7 @@
     },
     "node_modules/@koromix/koffi-linux-arm64": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.1.1.tgz",
       "integrity": "sha1-4IqFUqNrjCZXcdhow9xONe93+e4=",
       "cpu": [
         "arm64"
@@ -1240,7 +1246,7 @@
     },
     "node_modules/@koromix/koffi-linux-ia32": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.1.1.tgz",
       "integrity": "sha1-r+ZaFXc2SNsshp8+zxEV836JmdA=",
       "cpu": [
         "ia32"
@@ -1256,7 +1262,7 @@
     },
     "node_modules/@koromix/koffi-linux-loong64": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.1.1.tgz",
       "integrity": "sha1-YOyNd5cErW/yfj+YUfaFK5Jb18g=",
       "cpu": [
         "loong64"
@@ -1272,7 +1278,7 @@
     },
     "node_modules/@koromix/koffi-linux-riscv64": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.1.1.tgz",
       "integrity": "sha1-b72OZJMzSHlo3BAnNzmn2sTRgbc=",
       "cpu": [
         "riscv64"
@@ -1288,7 +1294,7 @@
     },
     "node_modules/@koromix/koffi-linux-x64": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.1.1.tgz",
       "integrity": "sha1-1maqrXPlVhJV915xyTg5nwpXEUU=",
       "cpu": [
         "x64"
@@ -1304,7 +1310,7 @@
     },
     "node_modules/@koromix/koffi-openbsd-ia32": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.1.1.tgz",
       "integrity": "sha1-sSdY1bQeFSdjoyQjBYA09XazZ5A=",
       "cpu": [
         "ia32"
@@ -1320,7 +1326,7 @@
     },
     "node_modules/@koromix/koffi-openbsd-x64": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.1.1.tgz",
       "integrity": "sha1-dfrAOwxryhHaQqI8G5g8uphxQUo=",
       "cpu": [
         "x64"
@@ -1336,7 +1342,7 @@
     },
     "node_modules/@koromix/koffi-win32-arm64": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.1.1.tgz",
       "integrity": "sha1-pHCGgaSi7wheOrZkpqrJrr3CiMQ=",
       "cpu": [
         "arm64"
@@ -1352,7 +1358,7 @@
     },
     "node_modules/@koromix/koffi-win32-ia32": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.1.1.tgz",
       "integrity": "sha1-ncGqz3gpNJX3U898zVzAhycOdtE=",
       "cpu": [
         "ia32"
@@ -1368,7 +1374,7 @@
     },
     "node_modules/@koromix/koffi-win32-x64": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.1.1.tgz",
       "integrity": "sha1-WERVlSEG4mSqtpoHIFEdzoGK6cs=",
       "cpu": [
         "x64"
@@ -1384,7 +1390,7 @@
     },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
       "integrity": "sha1-0Hct4apoCgv7m6LzK0yCjHhXy50=",
       "dev": true,
       "funding": [
@@ -1407,7 +1413,7 @@
     },
     "node_modules/@malept/flatpak-bundler": {
       "version": "0.4.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
       "integrity": "sha1-6KMsMKldIMKxu2NcxYCYGgY4mFg=",
       "dev": true,
       "license": "MIT",
@@ -1423,7 +1429,7 @@
     },
     "node_modules/@malept/flatpak-bundler/node_modules/fs-extra": {
       "version": "9.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fs-extra/-/fs-extra-9.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha1-WVRGDHZKjaIJS6NVS/g55rmnyG0=",
       "dev": true,
       "license": "MIT",
@@ -1439,7 +1445,7 @@
     },
     "node_modules/@mapbox/node-pre-gyp": {
       "version": "1.0.11",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
       "integrity": "sha1-QX20K39TI9eek7NKbXoqEsDfQ/o=",
       "license": "BSD-3-Clause",
       "optional": true,
@@ -1460,7 +1466,7 @@
     },
     "node_modules/@mapbox/node-pre-gyp/node_modules/agent-base": {
       "version": "6.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
       "license": "MIT",
       "optional": true,
@@ -1473,7 +1479,7 @@
     },
     "node_modules/@mapbox/node-pre-gyp/node_modules/chownr": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chownr/-/chownr-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha1-Fb++U9LqtM9w8YqM1o6+Wzyx3s4=",
       "license": "ISC",
       "optional": true,
@@ -1483,7 +1489,7 @@
     },
     "node_modules/@mapbox/node-pre-gyp/node_modules/https-proxy-agent": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
       "license": "MIT",
       "optional": true,
@@ -1497,7 +1503,7 @@
     },
     "node_modules/@mapbox/node-pre-gyp/node_modules/minipass": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
       "integrity": "sha1-PpeI/7kLaUpdDslEeaRbXYc4Ez0=",
       "license": "ISC",
       "optional": true,
@@ -1507,7 +1513,7 @@
     },
     "node_modules/@mapbox/node-pre-gyp/node_modules/minizlib": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minizlib/-/minizlib-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha1-6Q00Zrogm5MkUVCKEc49NjIUWTE=",
       "license": "MIT",
       "optional": true,
@@ -1521,7 +1527,7 @@
     },
     "node_modules/@mapbox/node-pre-gyp/node_modules/minizlib/node_modules/minipass": {
       "version": "3.3.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-3.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha1-e7o4TbOhUg0YycDlJRw0ROld2Uo=",
       "license": "ISC",
       "optional": true,
@@ -1534,7 +1540,7 @@
     },
     "node_modules/@mapbox/node-pre-gyp/node_modules/mkdirp": {
       "version": "1.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mkdirp/-/mkdirp-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
       "license": "MIT",
       "optional": true,
@@ -1547,7 +1553,7 @@
     },
     "node_modules/@mapbox/node-pre-gyp/node_modules/tar": {
       "version": "6.2.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tar/-/tar-6.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
       "integrity": "sha1-cXVJxUG8PCrxV1G+qUsd0GjUsDo=",
       "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
@@ -1566,7 +1572,7 @@
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
       "integrity": "sha1-7TOAbQ+b6Y3HbQw9T9hy/acBtdU=",
       "dev": true,
       "license": "MIT",
@@ -1585,7 +1591,7 @@
     },
     "node_modules/@noble/hashes": {
       "version": "2.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@noble/hashes/-/hashes-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
       "integrity": "sha1-ItodFqRplU/Oh3BV1VmQCmxztjs=",
       "dev": true,
       "license": "MIT",
@@ -1598,7 +1604,7 @@
     },
     "node_modules/@npmcli/agent": {
       "version": "2.2.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@npmcli/agent/-/agent-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-2.2.2.tgz",
       "integrity": "sha1-lnYEkY5i9iCmSMeXVGHJyedPxdU=",
       "license": "ISC",
       "optional": true,
@@ -1615,14 +1621,14 @@
     },
     "node_modules/@npmcli/agent/node_modules/lru-cache": {
       "version": "10.4.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-cache/-/lru-cache-10.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha1-QQ/IoXtw5ZgBPfJXwkRrfzOD8Rk=",
       "license": "ISC",
       "optional": true
     },
     "node_modules/@npmcli/fs": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@npmcli/fs/-/fs-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
       "integrity": "sha1-Wc2qWtypXRNfwA8rtT9XcVdc5yY=",
       "license": "ISC",
       "optional": true,
@@ -1635,7 +1641,7 @@
     },
     "node_modules/@oxc-project/types": {
       "version": "0.139.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@oxc-project/types/-/types-0.139.0.tgz",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
       "integrity": "sha1-ONdrnb+TTCoCvhdPsyzuvxgv50I=",
       "dev": true,
       "license": "MIT",
@@ -1645,7 +1651,7 @@
     },
     "node_modules/@peculiar/asn1-schema": {
       "version": "2.8.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
       "integrity": "sha1-aWmfhCWbIWFgfKv8NOUSpAI9vvk=",
       "dev": true,
       "license": "MIT",
@@ -1657,7 +1663,7 @@
     },
     "node_modules/@peculiar/json-schema": {
       "version": "1.1.12",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
       "integrity": "sha1-/mHoUlnjtbpa1WbLYsp1s9PNUzk=",
       "dev": true,
       "license": "MIT",
@@ -1670,7 +1676,7 @@
     },
     "node_modules/@peculiar/utils": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@peculiar/utils/-/utils-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
       "integrity": "sha1-onykxLc2UuEQ8Zp9FtZk9FilUo4=",
       "dev": true,
       "license": "MIT",
@@ -1680,7 +1686,7 @@
     },
     "node_modules/@peculiar/webcrypto": {
       "version": "1.7.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@peculiar/webcrypto/-/webcrypto-1.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.7.1.tgz",
       "integrity": "sha1-74z66HjKHxpE7wyCzz+m88vpwmo=",
       "dev": true,
       "license": "MIT",
@@ -1697,7 +1703,7 @@
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha1-p36nQvqyV3UUVDTrHSMoz1ATrDM=",
       "license": "MIT",
       "optional": true,
@@ -1707,31 +1713,31 @@
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha1-TIVzDlm5ofHzSQR9vyQpYDS7JzU=",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
       "integrity": "sha1-2TFa188/MKrHC9o8BoRD3G8UNlk=",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
       "integrity": "sha1-1RLLJsCuAmCR7iwRZ/G+b69chCo=",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
       "integrity": "sha1-TW/ADI+2QBalyBtGnVSQRjUPEGU=",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1740,31 +1746,31 @@
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@protobufjs/float/-/float-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@protobufjs/path/-/path-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
       "integrity": "sha1-eNR2Mz2F1bHHkuJXvKdLoIDaSaQ=",
       "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
       "integrity": "sha1-9Yy5oKgSjtBYIoJyBShUf8XANfM=",
       "cpu": [
         "arm64"
@@ -1781,7 +1787,7 @@
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
       "integrity": "sha1-RBFEwFpKgxqnUmmrw6SjJDdOpwc=",
       "cpu": [
         "arm64"
@@ -1798,7 +1804,7 @@
     },
     "node_modules/@rolldown/binding-darwin-x64": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
       "integrity": "sha1-yC4wZSzvUsSvkl1cZsiVWkAxmBY=",
       "cpu": [
         "x64"
@@ -1815,7 +1821,7 @@
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
       "integrity": "sha1-wy6c5/ocD7K4CROio6BcPpB9BrA=",
       "cpu": [
         "x64"
@@ -1832,7 +1838,7 @@
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
       "integrity": "sha1-zpC14iMWretQLqAQWC9JjNBgTyc=",
       "cpu": [
         "arm"
@@ -1849,7 +1855,7 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
       "integrity": "sha1-kZRxEMTdqk7vsATlJogHCXcIUgE=",
       "cpu": [
         "arm64"
@@ -1866,7 +1872,7 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
       "integrity": "sha1-6zKy1BCMHHArkejN6KBD6uXKqU0=",
       "cpu": [
         "arm64"
@@ -1883,7 +1889,7 @@
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
       "integrity": "sha1-zLlDwR5acmVcuwL8EWNUHOtkB4I=",
       "cpu": [
         "ppc64"
@@ -1900,7 +1906,7 @@
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
       "integrity": "sha1-ozcx7lZ+kLdfrG5eVTB+iiswOPA=",
       "cpu": [
         "s390x"
@@ -1917,7 +1923,7 @@
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
       "integrity": "sha1-p0wBqqzt/BHDm2/rozpfoMZUlJ8=",
       "cpu": [
         "x64"
@@ -1934,7 +1940,7 @@
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
       "integrity": "sha1-KM0XhJT6HmXbpBIim1zlXE3Vy9E=",
       "cpu": [
         "x64"
@@ -1951,7 +1957,7 @@
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
       "integrity": "sha1-98dfqRP8IIhNJqfUiNT1xZfNccA=",
       "cpu": [
         "arm64"
@@ -1968,7 +1974,7 @@
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
       "integrity": "sha1-w3lYGUd4cIHfNj6hBhQPzV/sJS0=",
       "cpu": [
         "wasm32"
@@ -1987,7 +1993,7 @@
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
       "version": "1.11.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/core/-/core-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha1-ueEGTzprFjHiQeY460jXNr/TcqY=",
       "dev": true,
       "license": "MIT",
@@ -1999,7 +2005,7 @@
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
       "version": "1.11.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha1-WPHz1dgamxL3k6tojJY3GQECfCQ=",
       "dev": true,
       "license": "MIT",
@@ -2021,7 +2027,7 @@
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
       "integrity": "sha1-8jyIaU96cpoS85UCSu4434Cha6M=",
       "cpu": [
         "arm64"
@@ -2038,7 +2044,7 @@
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
       "integrity": "sha1-M3fI3g5WqIV/ESF1YRRwkOh0y0Y=",
       "cpu": [
         "x64"
@@ -2055,14 +2061,14 @@
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha1-4/zuCT+7XOdl4a0Ij/TeKIn2+b4=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@sindresorhus/is/-/is-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha1-PHycRuZ4/u/nouW7YJ09vWZf+z8=",
       "dev": true,
       "license": "MIT",
@@ -2075,7 +2081,7 @@
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
       "integrity": "sha1-tKkUu2LnwnLU5Zif5EQPgSqx2Ac=",
       "dev": true,
       "license": "MIT",
@@ -2088,7 +2094,7 @@
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha1-AVy6np3UfOFNA9KoxdVHv7FpZl0=",
       "dev": true,
       "license": "MIT",
@@ -2099,7 +2105,7 @@
     },
     "node_modules/@types/archiver": {
       "version": "6.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/archiver/-/archiver-6.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.4.tgz",
       "integrity": "sha1-wkl9fwCbl/3Z7tb9GhW8gqvZ3BM=",
       "dev": true,
       "license": "MIT",
@@ -2109,7 +2115,7 @@
     },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
       "integrity": "sha1-pDCzJgRmyntcpb/XNWk7Nuep0YM=",
       "dev": true,
       "license": "MIT",
@@ -2122,7 +2128,7 @@
     },
     "node_modules/@types/debug": {
       "version": "4.1.13",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/debug/-/debug-4.1.13.tgz",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
       "integrity": "sha1-ItHMnVQtNZPK6nZPl0MGqzYobuc=",
       "dev": true,
       "license": "MIT",
@@ -2132,7 +2138,7 @@
     },
     "node_modules/@types/fs-extra": {
       "version": "9.0.13",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
       "integrity": "sha1-dZT7rgT+fxkYzos9IT90/0SsH0U=",
       "dev": true,
       "license": "MIT",
@@ -2142,14 +2148,14 @@
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha1-9qd4j0OMv94V8prK1GUStMAZE7M=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/keyv/-/keyv-3.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
       "integrity": "sha1-PM2xxnUbDH5SMAvNrNW8v4+qdbY=",
       "dev": true,
       "license": "MIT",
@@ -2159,14 +2165,14 @@
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/ms/-/ms-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha1-BSqmekjszEMJ1/AZG35BQ0uQu3g=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.20.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/node/-/node-22.20.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
       "integrity": "sha1-hOfN9jzaogwTSqMXzMkBqiHhbw4=",
       "license": "MIT",
       "dependencies": {
@@ -2175,7 +2181,7 @@
     },
     "node_modules/@types/react": {
       "version": "19.2.17",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/react/-/react-19.2.17.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha1-3MrDZbqg8XNOwnD/S1HIlGXo3H8=",
       "dev": true,
       "license": "MIT",
@@ -2185,7 +2191,7 @@
     },
     "node_modules/@types/react-dom": {
       "version": "19.2.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha1-weMF0VpSo+UI1U3Kdw0gLLY6vyw=",
       "dev": true,
       "license": "MIT",
@@ -2195,7 +2201,7 @@
     },
     "node_modules/@types/readdir-glob": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
       "integrity": "sha1-IaSpiJj8YGy1aK2BXyoO7cJNQSo=",
       "dev": true,
       "license": "MIT",
@@ -2205,7 +2211,7 @@
     },
     "node_modules/@types/responselike": {
       "version": "1.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/responselike/-/responselike-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
       "integrity": "sha1-zClwbwo5fP5t+J3r/kv1zqFZ21A=",
       "dev": true,
       "license": "MIT",
@@ -2215,7 +2221,7 @@
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
       "integrity": "sha1-zcfOgdYPHgkDSWDd+x+4gNendrY=",
       "cpu": [
         "ppc64"
@@ -2232,7 +2238,7 @@
     },
     "node_modules/@typescript/typescript-darwin-arm64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
       "integrity": "sha1-pV/fz6WN9Y0n2yI3zealweNacjU=",
       "cpu": [
         "arm64"
@@ -2249,7 +2255,7 @@
     },
     "node_modules/@typescript/typescript-darwin-x64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
       "integrity": "sha1-ONHJFygAqR1we+xk0qNwoBZjTbQ=",
       "cpu": [
         "x64"
@@ -2266,7 +2272,7 @@
     },
     "node_modules/@typescript/typescript-freebsd-arm64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
       "integrity": "sha1-8f+IEAMLNdK1vg22otxlBGDqlPo=",
       "cpu": [
         "arm64"
@@ -2283,7 +2289,7 @@
     },
     "node_modules/@typescript/typescript-freebsd-x64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
       "integrity": "sha1-PYawPzU8WxupUWLrbONVM7/ClL0=",
       "cpu": [
         "x64"
@@ -2300,7 +2306,7 @@
     },
     "node_modules/@typescript/typescript-linux-arm": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
       "integrity": "sha1-rZS0HhruKk3MaimMe2fEM0X94y4=",
       "cpu": [
         "arm"
@@ -2317,7 +2323,7 @@
     },
     "node_modules/@typescript/typescript-linux-arm64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
       "integrity": "sha1-2TNNltbaxv+F2pyGVYiUjek56R8=",
       "cpu": [
         "arm64"
@@ -2334,7 +2340,7 @@
     },
     "node_modules/@typescript/typescript-linux-loong64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
       "integrity": "sha1-KWWu5PyHM2ATnYk9qv5jl6KROK0=",
       "cpu": [
         "loong64"
@@ -2351,7 +2357,7 @@
     },
     "node_modules/@typescript/typescript-linux-mips64el": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
       "integrity": "sha1-Goh6MRvtOoM/gL/Uqe03wnGTbPA=",
       "cpu": [
         "mips64el"
@@ -2368,7 +2374,7 @@
     },
     "node_modules/@typescript/typescript-linux-ppc64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
       "integrity": "sha1-i2PJsvRFs5PrTkPsIdoiXa3jV30=",
       "cpu": [
         "ppc64"
@@ -2385,7 +2391,7 @@
     },
     "node_modules/@typescript/typescript-linux-riscv64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
       "integrity": "sha1-tuijXCibPql6kqQdRhqu7Q07NuE=",
       "cpu": [
         "riscv64"
@@ -2402,7 +2408,7 @@
     },
     "node_modules/@typescript/typescript-linux-s390x": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
       "integrity": "sha1-Lvlmk75IYfbReWVCflsAnLvtGj4=",
       "cpu": [
         "s390x"
@@ -2419,7 +2425,7 @@
     },
     "node_modules/@typescript/typescript-linux-x64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
       "integrity": "sha1-cyacsLq6UK6gygYERaa4jlg/HOI=",
       "cpu": [
         "x64"
@@ -2436,7 +2442,7 @@
     },
     "node_modules/@typescript/typescript-netbsd-arm64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
       "integrity": "sha1-OjZJ+X+vohC05uN5jBXgZgXIqQE=",
       "cpu": [
         "arm64"
@@ -2453,7 +2459,7 @@
     },
     "node_modules/@typescript/typescript-netbsd-x64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
       "integrity": "sha1-R+xZSRpAxHDSgH3E0rglUo/Zeas=",
       "cpu": [
         "x64"
@@ -2470,7 +2476,7 @@
     },
     "node_modules/@typescript/typescript-openbsd-arm64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
       "integrity": "sha1-eWvo2gvZidij+5bygB44qDZbS68=",
       "cpu": [
         "arm64"
@@ -2487,7 +2493,7 @@
     },
     "node_modules/@typescript/typescript-openbsd-x64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
       "integrity": "sha1-03/ipynrlCwHbEVO5/GBX699Vg8=",
       "cpu": [
         "x64"
@@ -2504,7 +2510,7 @@
     },
     "node_modules/@typescript/typescript-sunos-x64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
       "integrity": "sha1-q6jTRkw1ZacER4m6upaRa9SrLIg=",
       "cpu": [
         "x64"
@@ -2521,7 +2527,7 @@
     },
     "node_modules/@typescript/typescript-win32-arm64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
       "integrity": "sha1-ud5QoXGWOD9iYgtfnQovNK07YNc=",
       "cpu": [
         "arm64"
@@ -2538,7 +2544,7 @@
     },
     "node_modules/@typescript/typescript-win32-x64": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
       "integrity": "sha1-zzt7DWzlY12spMjgHBic3N5H7Dw=",
       "cpu": [
         "x64"
@@ -2555,7 +2561,7 @@
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
       "integrity": "sha1-VfHX9VhTTRCu8DwAfcIIt8N3HOQ=",
       "dev": true,
       "license": "MIT",
@@ -2581,7 +2587,7 @@
     },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.13",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
       "integrity": "sha1-ANHdlAshjf8uSTCdQQ2LshIVkiU=",
       "dev": true,
       "license": "MIT",
@@ -2591,14 +2597,14 @@
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/abbrev/-/abbrev-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
       "license": "ISC",
       "optional": true
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/abort-controller/-/abort-controller-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha1-6vVNU7YrrkE46AnKIlyEOabvs5I=",
       "license": "MIT",
       "dependencies": {
@@ -2610,7 +2616,7 @@
     },
     "node_modules/acorn": {
       "version": "8.17.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/acorn/-/acorn-8.17.0.tgz",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha1-F4WtuE+vjYrdEDabk4Jvwr0I8f4=",
       "dev": true,
       "license": "MIT",
@@ -2623,7 +2629,7 @@
     },
     "node_modules/adm-zip": {
       "version": "0.5.18",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/adm-zip/-/adm-zip-0.5.18.tgz",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
       "integrity": "sha1-KDoF8r8eP9MV8PMc3im3puPBYZ0=",
       "license": "MIT",
       "engines": {
@@ -2632,7 +2638,7 @@
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha1-48121MVI7oldPD/Y3B9sW5Ay56g=",
       "devOptional": true,
       "license": "MIT",
@@ -2642,7 +2648,7 @@
     },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
       "integrity": "sha1-kmcP9Q9TWb23o+DUDQ7DDFc3aHo=",
       "license": "MIT",
       "optional": true,
@@ -2656,7 +2662,7 @@
     },
     "node_modules/ajv": {
       "version": "8.20.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv/-/ajv-8.20.0.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha1-MEs2Nq3Yi6fZNnYN1Q7OAG3qlfk=",
       "dev": true,
       "license": "MIT",
@@ -2673,7 +2679,7 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
       "license": "MIT",
       "engines": {
@@ -2682,7 +2688,7 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
       "license": "MIT",
       "dependencies": {
@@ -2697,7 +2703,7 @@
     },
     "node_modules/app-builder-lib": {
       "version": "26.15.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/app-builder-lib/-/app-builder-lib-26.15.6.tgz",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.15.6.tgz",
       "integrity": "sha1-SlUhdKAnKh6M5e0Qjq86ZVnot3E=",
       "dev": true,
       "license": "MIT",
@@ -2754,7 +2760,7 @@
     },
     "node_modules/app-builder-lib/node_modules/@electron/get": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@electron/get/-/get-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-3.1.0.tgz",
       "integrity": "sha1-IsWgvZF6sgG63rd7xK0Yy6VMtOw=",
       "dev": true,
       "license": "MIT",
@@ -2776,7 +2782,7 @@
     },
     "node_modules/app-builder-lib/node_modules/@electron/get/node_modules/fs-extra": {
       "version": "8.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fs-extra/-/fs-extra-8.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
       "integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
       "dev": true,
       "license": "MIT",
@@ -2791,7 +2797,7 @@
     },
     "node_modules/app-builder-lib/node_modules/@electron/get/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-6.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha1-VW0u+GiRRuRtzqS/3QlfNDTf/LQ=",
       "dev": true,
       "license": "ISC",
@@ -2801,7 +2807,7 @@
     },
     "node_modules/app-builder-lib/node_modules/ci-info": {
       "version": "4.3.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ci-info/-/ci-info-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
       "integrity": "sha1-NVrVcZIIELViPhHUAjL0Q/FvHao=",
       "dev": true,
       "funding": [
@@ -2817,7 +2823,7 @@
     },
     "node_modules/app-builder-lib/node_modules/env-paths": {
       "version": "2.2.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/env-paths/-/env-paths-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha1-QgOZ1BbOH76bwKB8Yvpo1n/Q+PI=",
       "dev": true,
       "license": "MIT",
@@ -2827,7 +2833,7 @@
     },
     "node_modules/app-builder-lib/node_modules/jsonfile": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsonfile/-/jsonfile-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "license": "MIT",
@@ -2837,7 +2843,7 @@
     },
     "node_modules/app-builder-lib/node_modules/semver": {
       "version": "7.7.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha1-KEZONgYOmR+noR0CedLT87V6foo=",
       "dev": true,
       "license": "ISC",
@@ -2850,7 +2856,7 @@
     },
     "node_modules/app-builder-lib/node_modules/universalify": {
       "version": "0.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/universalify/-/universalify-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
       "dev": true,
       "license": "MIT",
@@ -2860,14 +2866,14 @@
     },
     "node_modules/aproba": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/aproba/-/aproba-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
       "integrity": "sha1-dVAKGQMT2Vxk6HHn5ChMasIZ8LE=",
       "license": "ISC",
       "optional": true
     },
     "node_modules/archiver": {
       "version": "7.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/archiver/-/archiver-7.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
       "integrity": "sha1-ydkcNQNiBAuJJzeceqacBlUSL2E=",
       "license": "MIT",
       "dependencies": {
@@ -2885,7 +2891,7 @@
     },
     "node_modules/archiver-utils": {
       "version": "5.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
       "integrity": "sha1-Y7xxnZUYA+/HLPlhpW74EHYN0U0=",
       "license": "MIT",
       "dependencies": {
@@ -2903,13 +2909,13 @@
     },
     "node_modules/archiver-utils/node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "license": "MIT"
     },
     "node_modules/archiver-utils/node_modules/brace-expansion": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
       "integrity": "sha1-C7oicf631Fiw0xrRNiWqpHVEMeI=",
       "license": "MIT",
       "dependencies": {
@@ -2918,7 +2924,7 @@
     },
     "node_modules/archiver-utils/node_modules/glob": {
       "version": "10.5.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/glob/-/glob-10.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha1-jsA1WRnNMzjChCiiPU8k7MX+c4w=",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
@@ -2939,7 +2945,7 @@
     },
     "node_modules/archiver-utils/node_modules/minimatch": {
       "version": "9.0.9",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-9.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha1-mwy5/LeAh/b9fqur4lEcTT1gV04=",
       "license": "ISC",
       "dependencies": {
@@ -2954,7 +2960,7 @@
     },
     "node_modules/archiver-utils/node_modules/readable-stream": {
       "version": "4.7.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/readable-stream/-/readable-stream-4.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha1-ztvYoRRsE9//jasUBoAo1YwVrJE=",
       "license": "MIT",
       "dependencies": {
@@ -2970,7 +2976,7 @@
     },
     "node_modules/archiver/node_modules/readable-stream": {
       "version": "4.7.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/readable-stream/-/readable-stream-4.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha1-ztvYoRRsE9//jasUBoAo1YwVrJE=",
       "license": "MIT",
       "dependencies": {
@@ -2986,7 +2992,7 @@
     },
     "node_modules/are-we-there-yet": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
       "integrity": "sha1-Ny4Oe9J52OlMZTqqH2cgCIS/Phw=",
       "deprecated": "This package is no longer supported.",
       "license": "ISC",
@@ -3001,14 +3007,14 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/argparse/-/argparse-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
       "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/asn1js": {
       "version": "3.0.10",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/asn1js/-/asn1js-3.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
       "integrity": "sha1-3ybIdMiotBymBe/qR7KtB1UQE90=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -3023,13 +3029,13 @@
     },
     "node_modules/async": {
       "version": "3.2.6",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/async/-/async-3.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha1-Gwco4Ukp1RuFtEm38G4nwRReOM4=",
       "license": "MIT"
     },
     "node_modules/async-exit-hook": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
       "integrity": "sha1-i9iwJLDsmxwBzMua+dspvXF9+vM=",
       "dev": true,
       "license": "MIT",
@@ -3039,14 +3045,14 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/at-least-node/-/at-least-node-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha1-YCzUtG6EStTv/JKoARo8RuAjjcI=",
       "dev": true,
       "license": "ISC",
@@ -3056,14 +3062,14 @@
     },
     "node_modules/aws4": {
       "version": "1.13.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/aws4/-/aws4-1.13.2.tgz",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
       "integrity": "sha1-CqFnIWllrJR0zPqDiSz7az4eUu8=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/b4a": {
       "version": "1.8.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/b4a/-/b4a-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
       "integrity": "sha1-fxYzTKgBJ66yYGSiiEGsvxdIQKQ=",
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -3077,7 +3083,7 @@
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha1-v7EGYv7tgZaixi58aOF3IMJ0F5o=",
       "dev": true,
       "license": "MIT",
@@ -3087,7 +3093,7 @@
     },
     "node_modules/bare-events": {
       "version": "2.9.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bare-events/-/bare-events-2.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
       "integrity": "sha1-XIZhaWY0O8sDobMVX+qyU+rb80k=",
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -3101,7 +3107,7 @@
     },
     "node_modules/bare-fs": {
       "version": "4.7.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bare-fs/-/bare-fs-4.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
       "integrity": "sha1-Q1CH1CR38Gft3zwsdG506dthd7w=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -3125,13 +3131,13 @@
     },
     "node_modules/bare-path": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bare-path/-/bare-path-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
       "integrity": "sha1-1KIHwIhgm0Zjp1VqRqlzQjmL9+I=",
       "license": "Apache-2.0"
     },
     "node_modules/bare-stream": {
       "version": "2.13.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bare-stream/-/bare-stream-2.13.3.tgz",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
       "integrity": "sha1-9hhsfLtLv1OkVg815IsWNzulHOY=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -3158,7 +3164,7 @@
     },
     "node_modules/bare-url": {
       "version": "2.4.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bare-url/-/bare-url-2.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
       "integrity": "sha1-UNIF+PJyTuxg/Qkbqc69Z1/KY6o=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -3167,7 +3173,7 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/base64-js/-/base64-js-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo=",
       "funding": [
         {
@@ -3187,21 +3193,21 @@
     },
     "node_modules/bluebird": {
       "version": "3.7.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bluebird/-/bluebird-3.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/boolean": {
       "version": "3.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/boolean/-/boolean-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
       "integrity": "sha1-nlKUr06YMUSUy7F5efpUyhWfEWs=",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "5.0.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
       "integrity": "sha1-Gw5GlltHna1lr3N7SgJ5CgVJgzc=",
       "dev": true,
       "license": "MIT",
@@ -3214,7 +3220,7 @@
     },
     "node_modules/buffer": {
       "version": "6.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/buffer/-/buffer-6.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha1-Ks5XhFnMj74qcKqo9S7mO2p0xsY=",
       "funding": [
         {
@@ -3238,7 +3244,7 @@
     },
     "node_modules/buffer-crc32": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
       "integrity": "sha1-oQmTuQVQgdVTBL2f60oHLeF59AU=",
       "license": "MIT",
       "engines": {
@@ -3247,14 +3253,14 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/buffer-from/-/buffer-from-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha1-KxRqb9cugLT1XSVfNe1Zo6mkG9U=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/builder-util": {
       "version": "26.15.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/builder-util/-/builder-util-26.15.3.tgz",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.15.3.tgz",
       "integrity": "sha1-Huqzfw1KZCH+GM6ds4ztWIgdlRk=",
       "dev": true,
       "license": "MIT",
@@ -3280,7 +3286,7 @@
     },
     "node_modules/builder-util-runtime": {
       "version": "9.7.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
       "integrity": "sha1-yG+6MDaE6Hfa7hXCnu3oGYcWb+8=",
       "dev": true,
       "license": "MIT",
@@ -3294,7 +3300,7 @@
     },
     "node_modules/bytestreamjs": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
       "integrity": "sha1-oylHx844mm+hGgmppWPQpFiJU14=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -3304,7 +3310,7 @@
     },
     "node_modules/cacache": {
       "version": "18.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cacache/-/cacache-18.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.4.tgz",
       "integrity": "sha1-RgHXV42ttZxmBE4VfQKjMUaC1qU=",
       "license": "ISC",
       "optional": true,
@@ -3328,14 +3334,14 @@
     },
     "node_modules/cacache/node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "license": "MIT",
       "optional": true
     },
     "node_modules/cacache/node_modules/brace-expansion": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
       "integrity": "sha1-C7oicf631Fiw0xrRNiWqpHVEMeI=",
       "license": "MIT",
       "optional": true,
@@ -3345,7 +3351,7 @@
     },
     "node_modules/cacache/node_modules/chownr": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chownr/-/chownr-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha1-Fb++U9LqtM9w8YqM1o6+Wzyx3s4=",
       "license": "ISC",
       "optional": true,
@@ -3355,7 +3361,7 @@
     },
     "node_modules/cacache/node_modules/fs-minipass": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fs-minipass/-/fs-minipass-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
       "integrity": "sha1-eahZgcTcEgBl6W9iCGv2+dwmzFQ=",
       "license": "ISC",
       "optional": true,
@@ -3368,7 +3374,7 @@
     },
     "node_modules/cacache/node_modules/glob": {
       "version": "10.5.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/glob/-/glob-10.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha1-jsA1WRnNMzjChCiiPU8k7MX+c4w=",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
@@ -3390,14 +3396,14 @@
     },
     "node_modules/cacache/node_modules/lru-cache": {
       "version": "10.4.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-cache/-/lru-cache-10.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha1-QQ/IoXtw5ZgBPfJXwkRrfzOD8Rk=",
       "license": "ISC",
       "optional": true
     },
     "node_modules/cacache/node_modules/minimatch": {
       "version": "9.0.9",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-9.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha1-mwy5/LeAh/b9fqur4lEcTT1gV04=",
       "license": "ISC",
       "optional": true,
@@ -3413,7 +3419,7 @@
     },
     "node_modules/cacache/node_modules/minizlib": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minizlib/-/minizlib-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha1-6Q00Zrogm5MkUVCKEc49NjIUWTE=",
       "license": "MIT",
       "optional": true,
@@ -3427,7 +3433,7 @@
     },
     "node_modules/cacache/node_modules/minizlib/node_modules/minipass": {
       "version": "3.3.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-3.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha1-e7o4TbOhUg0YycDlJRw0ROld2Uo=",
       "license": "ISC",
       "optional": true,
@@ -3440,7 +3446,7 @@
     },
     "node_modules/cacache/node_modules/mkdirp": {
       "version": "1.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mkdirp/-/mkdirp-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
       "license": "MIT",
       "optional": true,
@@ -3453,7 +3459,7 @@
     },
     "node_modules/cacache/node_modules/tar": {
       "version": "6.2.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tar/-/tar-6.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
       "integrity": "sha1-cXVJxUG8PCrxV1G+qUsd0GjUsDo=",
       "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
@@ -3472,7 +3478,7 @@
     },
     "node_modules/cacache/node_modules/tar/node_modules/fs-minipass": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha1-f1A2/b8SxjwWkZDL5BmchSJx+fs=",
       "license": "ISC",
       "optional": true,
@@ -3485,7 +3491,7 @@
     },
     "node_modules/cacache/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
       "version": "3.3.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-3.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha1-e7o4TbOhUg0YycDlJRw0ROld2Uo=",
       "license": "ISC",
       "optional": true,
@@ -3498,7 +3504,7 @@
     },
     "node_modules/cacache/node_modules/tar/node_modules/minipass": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
       "integrity": "sha1-PpeI/7kLaUpdDslEeaRbXYc4Ez0=",
       "license": "ISC",
       "optional": true,
@@ -3508,7 +3514,7 @@
     },
     "node_modules/cacheable-lookup": {
       "version": "5.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
       "integrity": "sha1-WmuGWyxENXvj1evCpGewMnGacAU=",
       "dev": true,
       "license": "MIT",
@@ -3518,7 +3524,7 @@
     },
     "node_modules/cacheable-request": {
       "version": "7.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
       "integrity": "sha1-ejPr8IYTF4tANjW+e4mdPmm76Bc=",
       "dev": true,
       "license": "MIT",
@@ -3537,7 +3543,7 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha1-S1QowiK+mF15w9gmV0edvgtZstY=",
       "dev": true,
       "license": "MIT",
@@ -3551,7 +3557,7 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chalk/-/chalk-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
       "dev": true,
       "license": "MIT",
@@ -3568,7 +3574,7 @@
     },
     "node_modules/chownr": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chownr/-/chownr-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
       "integrity": "sha1-mFXmTs0kCpzEJnzopKpdJKHaFeQ=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -3578,14 +3584,14 @@
     },
     "node_modules/chromium-pickle-js": {
       "version": "0.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
       "integrity": "sha1-BKEGZywYsIWrd02YPfo+oTjyIgU=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/ci-info": {
       "version": "4.4.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ci-info/-/ci-info-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
       "integrity": "sha1-fVTv+fVLRbYkAcJgMmlutZyL0Yw=",
       "dev": true,
       "funding": [
@@ -3601,7 +3607,7 @@
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/clean-stack/-/clean-stack-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs=",
       "license": "MIT",
       "optional": true,
@@ -3611,7 +3617,7 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cliui/-/cliui-8.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha1-DASwddsCy/5g3I5s8vVIaxo2CKo=",
       "dev": true,
       "license": "ISC",
@@ -3626,7 +3632,7 @@
     },
     "node_modules/clone-response": {
       "version": "1.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/clone-response/-/clone-response-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
       "integrity": "sha1-ryAyqkeBY5nPXwodDbkC9ReruMM=",
       "dev": true,
       "license": "MIT",
@@ -3639,7 +3645,7 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
       "license": "MIT",
       "dependencies": {
@@ -3651,13 +3657,13 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/color-name/-/color-name-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
       "license": "MIT"
     },
     "node_modules/color-support": {
       "version": "1.1.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/color-support/-/color-support-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha1-k4NDeaHMmgxh+C9S8NBDIiUb1aI=",
       "license": "ISC",
       "optional": true,
@@ -3667,7 +3673,7 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
       "dev": true,
       "license": "MIT",
@@ -3680,7 +3686,7 @@
     },
     "node_modules/commander": {
       "version": "5.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/commander/-/commander-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
       "integrity": "sha1-Rqu9FlL44Fm92u+Zu9yyrZzxea4=",
       "dev": true,
       "license": "MIT",
@@ -3690,7 +3696,7 @@
     },
     "node_modules/compare-version": {
       "version": "0.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/compare-version/-/compare-version-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
       "integrity": "sha1-AWLsLZNR9d3VmpICy6k1NmpyUIA=",
       "dev": true,
       "license": "MIT",
@@ -3700,7 +3706,7 @@
     },
     "node_modules/compress-commons": {
       "version": "6.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/compress-commons/-/compress-commons-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
       "integrity": "sha1-JtMSUaZrnWuiOoQGTs06anHSYJ4=",
       "license": "MIT",
       "dependencies": {
@@ -3716,7 +3722,7 @@
     },
     "node_modules/compress-commons/node_modules/readable-stream": {
       "version": "4.7.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/readable-stream/-/readable-stream-4.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha1-ztvYoRRsE9//jasUBoAo1YwVrJE=",
       "license": "MIT",
       "dependencies": {
@@ -3732,34 +3738,34 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/confbox": {
       "version": "0.2.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/confbox/-/confbox-0.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha1-WS575x+IKkqHTjyI8Kwe9vfaHOU=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "license": "ISC",
       "optional": true
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/core-util-is/-/core-util-is-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha1-pgQtNjTCsn6TKPg3uWX6yDgI24U=",
       "license": "MIT"
     },
     "node_modules/crc-32": {
       "version": "1.2.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/crc-32/-/crc-32-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
       "integrity": "sha1-PK01qTS4v3HyXKUkttpR+36s4v8=",
       "license": "Apache-2.0",
       "bin": {
@@ -3771,7 +3777,7 @@
     },
     "node_modules/crc32-stream": {
       "version": "6.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
       "integrity": "sha1-hSmjho+LJ6u5FfbDYXwPre2/lDA=",
       "license": "MIT",
       "dependencies": {
@@ -3784,7 +3790,7 @@
     },
     "node_modules/crc32-stream/node_modules/readable-stream": {
       "version": "4.7.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/readable-stream/-/readable-stream-4.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha1-ztvYoRRsE9//jasUBoAo1YwVrJE=",
       "license": "MIT",
       "dependencies": {
@@ -3800,7 +3806,7 @@
     },
     "node_modules/cross-dirname": {
       "version": "0.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cross-dirname/-/cross-dirname-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
       "integrity": "sha1-uJlZnzClOJ9Z54wVDhn5V60Wo3w=",
       "dev": true,
       "license": "MIT",
@@ -3809,7 +3815,7 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha1-ilj+ePANzXDDcEUXWd+/rwPo7p8=",
       "license": "MIT",
       "dependencies": {
@@ -3823,13 +3829,13 @@
     },
     "node_modules/cross-spawn/node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "license": "ISC"
     },
     "node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/which/-/which-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
       "license": "ISC",
       "dependencies": {
@@ -3844,14 +3850,14 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/csstype/-/csstype-3.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha1-7EjA8+mT5QZIyG2lWeJhCZXPmJo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
       "devOptional": true,
       "license": "MIT",
@@ -3869,7 +3875,7 @@
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/decompress-response/-/decompress-response-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha1-yjh2Et234QS9FthaqwDV7PCcZvw=",
       "dev": true,
       "license": "MIT",
@@ -3885,7 +3891,7 @@
     },
     "node_modules/decompress-response/node_modules/mimic-response": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mimic-response/-/mimic-response-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha1-LR1Zr5wbEpgVrMwsRqAipc4fo8k=",
       "dev": true,
       "license": "MIT",
@@ -3898,7 +3904,7 @@
     },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha1-gBa9tBQ+RjK3ejRJxiNid95SBYc=",
       "dev": true,
       "license": "MIT",
@@ -3908,7 +3914,7 @@
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/define-data-property/-/define-data-property-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha1-iU3BQbt9MGCuQ2b2oBB+aPvkjF4=",
       "license": "MIT",
       "dependencies": {
@@ -3925,7 +3931,7 @@
     },
     "node_modules/define-properties": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/define-properties/-/define-properties-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha1-EHgcxhbrlRqAoDS6/Kpzd/avK2w=",
       "license": "MIT",
       "dependencies": {
@@ -3942,7 +3948,7 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true,
       "license": "MIT",
@@ -3952,14 +3958,14 @@
     },
     "node_modules/delegates": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/delegates/-/delegates-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "license": "MIT",
       "optional": true
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/detect-libc/-/detect-libc-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha1-aJxdzcGQDvVYOky59te0c3QgdK0=",
       "license": "Apache-2.0",
       "engines": {
@@ -3968,13 +3974,13 @@
     },
     "node_modules/detect-node": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/detect-node/-/detect-node-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha1-yccHdaScPQO8LAbZpzvlUPl4+LE=",
       "license": "MIT"
     },
     "node_modules/dir-compare": {
       "version": "4.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dir-compare/-/dir-compare-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz",
       "integrity": "sha1-0dSZnBT79VKBBx/a5Ck7O5zobxk=",
       "dev": true,
       "license": "MIT",
@@ -3985,14 +3991,14 @@
     },
     "node_modules/dir-compare/node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/dir-compare/node_modules/brace-expansion": {
       "version": "1.1.16",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
       "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
       "dev": true,
       "license": "MIT",
@@ -4003,7 +4009,7 @@
     },
     "node_modules/dir-compare/node_modules/minimatch": {
       "version": "3.1.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
       "dev": true,
       "license": "ISC",
@@ -4016,7 +4022,7 @@
     },
     "node_modules/dmg-builder": {
       "version": "26.15.6",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dmg-builder/-/dmg-builder-26.15.6.tgz",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.15.6.tgz",
       "integrity": "sha1-PQy/HT3GumvxmDaOW9rPGnNLYPw=",
       "dev": true,
       "license": "MIT",
@@ -4029,7 +4035,7 @@
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dotenv/-/dotenv-16.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha1-dz8OaVJ6gxXHKF1e5zxEWdIKgCA=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -4042,7 +4048,7 @@
     },
     "node_modules/dotenv-expand": {
       "version": "11.0.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
       "integrity": "sha1-r2la6gB9b9yEyGzY0K1760CgvQg=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -4058,7 +4064,7 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha1-165mfh3INIL4tw/Q9u78UNow9Yo=",
       "dev": true,
       "license": "MIT",
@@ -4073,7 +4079,7 @@
     },
     "node_modules/duplexer2": {
       "version": "0.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/duplexer2/-/duplexer2-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -4083,7 +4089,7 @@
     },
     "node_modules/duplexer2/node_modules/readable-stream": {
       "version": "2.3.8",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/readable-stream/-/readable-stream-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha1-kRJegEK7obmIf0k0X2J3Anzovps=",
       "dev": true,
       "license": "MIT",
@@ -4099,14 +4105,14 @@
     },
     "node_modules/duplexer2/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/duplexer2/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "dev": true,
       "license": "MIT",
@@ -4116,13 +4122,13 @@
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha1-aWzi7Aqg5uqTo5f/zySqeEDIJ8s=",
       "license": "MIT"
     },
     "node_modules/ejs": {
       "version": "3.1.10",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ejs/-/ejs-3.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
       "integrity": "sha1-aauDWLFOiW+AzDnmIIe4hQDDrDs=",
       "dev": true,
       "license": "Apache-2.0",
@@ -4138,7 +4144,7 @@
     },
     "node_modules/electron": {
       "version": "43.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/electron/-/electron-43.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.1.1.tgz",
       "integrity": "sha1-pzCcamJdb2YhsRCKZb1TraEYT6k=",
       "dev": true,
       "license": "MIT",
@@ -4157,7 +4163,7 @@
     },
     "node_modules/electron-builder": {
       "version": "26.15.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/electron-builder/-/electron-builder-26.15.6.tgz",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.6.tgz",
       "integrity": "sha1-Lxl+KHRpfrv4kpGVEW9/tYrUugo=",
       "dev": true,
       "license": "MIT",
@@ -4183,7 +4189,7 @@
     },
     "node_modules/electron-builder-squirrel-windows": {
       "version": "26.15.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.6.tgz",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.6.tgz",
       "integrity": "sha1-eN6cXbNami9IZs2wVQT5aQPTk3I=",
       "dev": true,
       "license": "MIT",
@@ -4196,7 +4202,7 @@
     },
     "node_modules/electron-publish": {
       "version": "26.15.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/electron-publish/-/electron-publish-26.15.3.tgz",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.15.3.tgz",
       "integrity": "sha1-22VkIHC/YMe9JtYHRBUGiR060FQ=",
       "dev": true,
       "license": "MIT",
@@ -4214,7 +4220,7 @@
     },
     "node_modules/electron-winstaller": {
       "version": "5.4.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
       "integrity": "sha1-8GYNR21cT1ef337dLwzwHVTE0LI=",
       "dev": true,
       "hasInstallScript": true,
@@ -4236,7 +4242,7 @@
     },
     "node_modules/electron-winstaller/node_modules/fs-extra": {
       "version": "7.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fs-extra/-/fs-extra-7.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha1-TxicRKoSO4lfcigE9V6iPq3DSOk=",
       "dev": true,
       "license": "MIT",
@@ -4252,7 +4258,7 @@
     },
     "node_modules/electron-winstaller/node_modules/jsonfile": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsonfile/-/jsonfile-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "license": "MIT",
@@ -4263,7 +4269,7 @@
     },
     "node_modules/electron-winstaller/node_modules/universalify": {
       "version": "0.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/universalify/-/universalify-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
       "dev": true,
       "license": "MIT",
@@ -4274,7 +4280,7 @@
     },
     "node_modules/electron/node_modules/@types/node": {
       "version": "24.13.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/node/-/node-24.13.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
       "integrity": "sha1-SfGL08ZHhm3NpRoHVsFF4UWQzhY=",
       "dev": true,
       "license": "MIT",
@@ -4284,20 +4290,20 @@
     },
     "node_modules/electron/node_modules/undici-types": {
       "version": "7.18.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/undici-types/-/undici-types-7.18.2.tgz",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha1-KTV6iee3ykrvO/D9P9DNc4hCKek=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "license": "MIT"
     },
     "node_modules/encoding": {
       "version": "0.1.13",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/encoding/-/encoding-0.1.13.tgz",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha1-VldK/deR9UqOmyeFwFgqLSYhD6k=",
       "license": "MIT",
       "optional": true,
@@ -4307,7 +4313,7 @@
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha1-c0TXEd6kDgt0q8LtSXeHQ8ztsIw=",
       "dev": true,
       "license": "MIT",
@@ -4317,7 +4323,7 @@
     },
     "node_modules/env-paths": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/env-paths/-/env-paths-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
       "integrity": "sha1-Lx6Jwvbb00COGxcR3YLWLjF/WNo=",
       "dev": true,
       "license": "MIT",
@@ -4330,14 +4336,14 @@
     },
     "node_modules/err-code": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/err-code/-/err-code-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
       "integrity": "sha1-I8Lzt1b/38YI0w4nyalBAkgH5/k=",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-define-property/-/es-define-property-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha1-mD6y+aZyTpMD9hrd8BHHLgngsPo=",
       "license": "MIT",
       "engines": {
@@ -4346,7 +4352,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-errors/-/es-errors-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8=",
       "license": "MIT",
       "engines": {
@@ -4355,7 +4361,7 @@
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha1-otCzcyBXJN+lJdI7DD4bHKWCyZs=",
       "dev": true,
       "license": "MIT",
@@ -4368,7 +4374,7 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha1-8x274MGDsAptJutjJcgQwP0YvU0=",
       "dev": true,
       "license": "MIT",
@@ -4384,13 +4390,13 @@
     },
     "node_modules/es6-error": {
       "version": "4.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es6-error/-/es6-error-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha1-njr0B0Wd7tR+mpH5uIWoTrBcVh0=",
       "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/escalade/-/escalade-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
       "dev": true,
       "license": "MIT",
@@ -4400,7 +4406,7 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=",
       "license": "MIT",
       "engines": {
@@ -4412,7 +4418,7 @@
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha1-XU0+vflYPWOlMzzi3rdICrKwV4k=",
       "license": "MIT",
       "engines": {
@@ -4421,7 +4427,7 @@
     },
     "node_modules/events": {
       "version": "3.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/events/-/events-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA=",
       "license": "MIT",
       "engines": {
@@ -4430,7 +4436,7 @@
     },
     "node_modules/events-universal": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/events-universal/-/events-universal-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
       "integrity": "sha1-tWqE/WEbZhDgotDwn4D9+THi3+Y=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -4439,34 +4445,34 @@
     },
     "node_modules/exponential-backoff": {
       "version": "3.1.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
       "integrity": "sha1-Uc+SwcBJPHZgU/nTq+5ENMJE0vY=",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/exsolve": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/exsolve/-/exsolve-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
       "integrity": "sha1-re+psYs/NRXpRtSOsso7sPLFG00=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha1-KG4x3pbrltOKl4mYFXQLoqTzZAw=",
       "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.1.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-uri/-/fast-uri-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
       "integrity": "sha1-9pWkDwBqulBWMVc6ACHdshGUrRE=",
       "dev": true,
       "funding": [
@@ -4483,7 +4489,7 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fdir/-/fdir-6.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha1-7Sq5Z6MxreYvGNB32uGSaE1Q01A=",
       "dev": true,
       "license": "MIT",
@@ -4501,7 +4507,7 @@
     },
     "node_modules/filelist": {
       "version": "1.0.6",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/filelist/-/filelist-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
       "integrity": "sha1-HohwlCp8Y2yGL3xJuTlJN7aplaM=",
       "dev": true,
       "license": "Apache-2.0",
@@ -4511,14 +4517,14 @@
     },
     "node_modules/filelist/node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
       "integrity": "sha1-C7oicf631Fiw0xrRNiWqpHVEMeI=",
       "dev": true,
       "license": "MIT",
@@ -4528,7 +4534,7 @@
     },
     "node_modules/filelist/node_modules/minimatch": {
       "version": "5.1.9",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-5.1.9.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
       "integrity": "sha1-EpPvFdsAmLOUVA6Pn3RPn9qN7ks=",
       "dev": true,
       "license": "ISC",
@@ -4541,13 +4547,13 @@
     },
     "node_modules/flatbuffers": {
       "version": "25.9.23",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
       "integrity": "sha1-NGgRVX/pMSq1ZHU155PHYenIHrE=",
       "license": "Apache-2.0"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/foreground-child/-/foreground-child-3.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha1-Mujp7Rtoo0l777msK2rfkqY4V28=",
       "license": "ISC",
       "dependencies": {
@@ -4563,7 +4569,7 @@
     },
     "node_modules/foreground-child/node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/signal-exit/-/signal-exit-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha1-lSGIwcvVRgcOLdIND0HArgUwywQ=",
       "license": "ISC",
       "engines": {
@@ -4575,7 +4581,7 @@
     },
     "node_modules/form-data": {
       "version": "4.0.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/form-data/-/form-data-4.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
       "integrity": "sha1-KOhk4beG2+u2jbH0UvljUnhmWCc=",
       "dev": true,
       "license": "MIT",
@@ -4592,7 +4598,7 @@
     },
     "node_modules/fs-extra": {
       "version": "10.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fs-extra/-/fs-extra-10.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha1-Aoc8+8QITd4SfqpfmQXu8jJdGr8=",
       "dev": true,
       "license": "MIT",
@@ -4607,7 +4613,7 @@
     },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha1-f1A2/b8SxjwWkZDL5BmchSJx+fs=",
       "license": "ISC",
       "optional": true,
@@ -4620,7 +4626,7 @@
     },
     "node_modules/fs-minipass/node_modules/minipass": {
       "version": "3.3.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-3.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha1-e7o4TbOhUg0YycDlJRw0ROld2Uo=",
       "license": "ISC",
       "optional": true,
@@ -4633,14 +4639,14 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "devOptional": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha1-ysZAd4XQNnWipeGlMFxpezR9kNY=",
       "dev": true,
       "license": "MIT",
@@ -4654,7 +4660,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw=",
       "dev": true,
       "license": "MIT",
@@ -4664,7 +4670,7 @@
     },
     "node_modules/gauge": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/gauge/-/gauge-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
       "integrity": "sha1-A79EQcBEODkIvPoGVq2RgDJZs5U=",
       "deprecated": "This package is no longer supported.",
       "license": "ISC",
@@ -4686,7 +4692,7 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
       "dev": true,
       "license": "ISC",
@@ -4696,7 +4702,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha1-dD8OO2lkqTpUke0b/6rgVNf5jQE=",
       "dev": true,
       "license": "MIT",
@@ -4721,7 +4727,7 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-proto/-/get-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha1-FQs/J0OGnvPoUewMSdFbHRTQDuE=",
       "dev": true,
       "license": "MIT",
@@ -4735,7 +4741,7 @@
     },
     "node_modules/get-stream": {
       "version": "5.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-stream/-/get-stream-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha1-SWaheV7lrOZecGxLe+txJX1uItM=",
       "dev": true,
       "license": "MIT",
@@ -4751,7 +4757,7 @@
     },
     "node_modules/get-windows": {
       "version": "9.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-windows/-/get-windows-9.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-windows/-/get-windows-9.3.0.tgz",
       "integrity": "sha1-waEA4kcjEctVIWomIIMqL4ooGrw=",
       "hasInstallScript": true,
       "license": "MIT",
@@ -4778,7 +4784,7 @@
     },
     "node_modules/get-windows/node_modules/abbrev": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/abbrev/-/abbrev-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
       "integrity": "sha1-z1mCm4tPA/id2idxy382U4KMib8=",
       "license": "ISC",
       "optional": true,
@@ -4788,14 +4794,14 @@
     },
     "node_modules/get-windows/node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "license": "MIT",
       "optional": true
     },
     "node_modules/get-windows/node_modules/brace-expansion": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
       "integrity": "sha1-C7oicf631Fiw0xrRNiWqpHVEMeI=",
       "license": "MIT",
       "optional": true,
@@ -4805,7 +4811,7 @@
     },
     "node_modules/get-windows/node_modules/chownr": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chownr/-/chownr-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha1-Fb++U9LqtM9w8YqM1o6+Wzyx3s4=",
       "license": "ISC",
       "optional": true,
@@ -4815,7 +4821,7 @@
     },
     "node_modules/get-windows/node_modules/env-paths": {
       "version": "2.2.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/env-paths/-/env-paths-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha1-QgOZ1BbOH76bwKB8Yvpo1n/Q+PI=",
       "license": "MIT",
       "optional": true,
@@ -4825,7 +4831,7 @@
     },
     "node_modules/get-windows/node_modules/glob": {
       "version": "10.5.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/glob/-/glob-10.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha1-jsA1WRnNMzjChCiiPU8k7MX+c4w=",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
@@ -4847,7 +4853,7 @@
     },
     "node_modules/get-windows/node_modules/minimatch": {
       "version": "9.0.9",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-9.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha1-mwy5/LeAh/b9fqur4lEcTT1gV04=",
       "license": "ISC",
       "optional": true,
@@ -4863,7 +4869,7 @@
     },
     "node_modules/get-windows/node_modules/minizlib": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minizlib/-/minizlib-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha1-6Q00Zrogm5MkUVCKEc49NjIUWTE=",
       "license": "MIT",
       "optional": true,
@@ -4877,7 +4883,7 @@
     },
     "node_modules/get-windows/node_modules/minizlib/node_modules/minipass": {
       "version": "3.3.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-3.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha1-e7o4TbOhUg0YycDlJRw0ROld2Uo=",
       "license": "ISC",
       "optional": true,
@@ -4890,7 +4896,7 @@
     },
     "node_modules/get-windows/node_modules/mkdirp": {
       "version": "1.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mkdirp/-/mkdirp-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
       "license": "MIT",
       "optional": true,
@@ -4903,7 +4909,7 @@
     },
     "node_modules/get-windows/node_modules/node-gyp": {
       "version": "10.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-gyp/-/node-gyp-10.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-10.3.1.tgz",
       "integrity": "sha1-HdGhocbFxZ2hp2rqBqBieGssiho=",
       "license": "MIT",
       "optional": true,
@@ -4928,7 +4934,7 @@
     },
     "node_modules/get-windows/node_modules/nopt": {
       "version": "7.2.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nopt/-/nopt-7.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
       "integrity": "sha1-HKwOq5uOl8kJMzhEbt3UCyyMoec=",
       "license": "ISC",
       "optional": true,
@@ -4944,7 +4950,7 @@
     },
     "node_modules/get-windows/node_modules/proc-log": {
       "version": "4.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/proc-log/-/proc-log-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
       "integrity": "sha1-tvRh5AJudf3+IosmXp96AHedcDQ=",
       "license": "ISC",
       "optional": true,
@@ -4954,7 +4960,7 @@
     },
     "node_modules/get-windows/node_modules/tar": {
       "version": "6.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tar/-/tar-6.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
       "integrity": "sha1-cXVJxUG8PCrxV1G+qUsd0GjUsDo=",
       "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
@@ -4973,7 +4979,7 @@
     },
     "node_modules/get-windows/node_modules/tar/node_modules/minipass": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
       "integrity": "sha1-PpeI/7kLaUpdDslEeaRbXYc4Ez0=",
       "license": "ISC",
       "optional": true,
@@ -4983,7 +4989,7 @@
     },
     "node_modules/get-windows/node_modules/which": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/which/-/which-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
       "integrity": "sha1-zWC150UDo/vPv2zWtBOKi65kTBo=",
       "license": "ISC",
       "optional": true,
@@ -4999,7 +5005,7 @@
     },
     "node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/glob/-/glob-7.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "devOptional": true,
@@ -5021,14 +5027,14 @@
     },
     "node_modules/glob/node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "1.1.16",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
       "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
       "devOptional": true,
       "license": "MIT",
@@ -5039,7 +5045,7 @@
     },
     "node_modules/glob/node_modules/minimatch": {
       "version": "3.1.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
       "devOptional": true,
       "license": "ISC",
@@ -5052,7 +5058,7 @@
     },
     "node_modules/global-agent": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/global-agent/-/global-agent-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
       "integrity": "sha1-rnzTG9NYO5PFoWQ3oa/ifMM6GrY=",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5069,7 +5075,7 @@
     },
     "node_modules/globalthis": {
       "version": "1.0.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/globalthis/-/globalthis-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha1-dDDtOpddl7+1m8zkH1yruvplEjY=",
       "license": "MIT",
       "dependencies": {
@@ -5085,7 +5091,7 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/gopd/-/gopd-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha1-ifVrghe9vIgCvSmd9tfxCB1+UaE=",
       "license": "MIT",
       "engines": {
@@ -5097,7 +5103,7 @@
     },
     "node_modules/got": {
       "version": "11.8.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/got/-/got-11.8.6.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
       "integrity": "sha1-J26Cfq2Hcu3bz8lxcFkLhBgjIzo=",
       "dev": true,
       "license": "MIT",
@@ -5123,19 +5129,19 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha1-QYPk6L8Iu24Fu7L30uDI9xLKQOM=",
       "license": "ISC"
     },
     "node_modules/guid-typescript": {
       "version": "1.0.9",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
       "integrity": "sha1-4193ADU1sCl+oIVI9azmrbFIDdw=",
       "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
       "dev": true,
       "license": "MIT",
@@ -5145,7 +5151,7 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha1-lj7X0HHce/XwhMW/vg0bYiJYaFQ=",
       "license": "MIT",
       "dependencies": {
@@ -5157,7 +5163,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/has-symbols/-/has-symbols-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha1-/JxqeDoISVHQuXH+EBjegTcHozg=",
       "dev": true,
       "license": "MIT",
@@ -5170,7 +5176,7 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha1-LNxC1AvvLltO6rfAGnPFTOerWrw=",
       "dev": true,
       "license": "MIT",
@@ -5186,14 +5192,14 @@
     },
     "node_modules/has-unicode": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/has-unicode/-/has-unicode-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "license": "ISC",
       "optional": true
     },
     "node_modules/hasown": {
       "version": "2.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hasown/-/hasown-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
       "dev": true,
       "license": "MIT",
@@ -5206,7 +5212,7 @@
     },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
       "integrity": "sha1-gnuChn6f8cjQxNnVOIA5fSyG0iQ=",
       "dev": true,
       "license": "ISC",
@@ -5219,14 +5225,14 @@
     },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha1-IF9Ntk+FYrdqT/kjWqUnmDmgndU=",
       "devOptional": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha1-mosfJGhmwChQlIZYX2K48sGMJw4=",
       "devOptional": true,
       "license": "MIT",
@@ -5240,7 +5246,7 @@
     },
     "node_modules/http2-wrapper": {
       "version": "1.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
       "integrity": "sha1-uPVeDB8l1OvQizsMLAeflZCACz0=",
       "dev": true,
       "license": "MIT",
@@ -5254,7 +5260,7 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha1-2o3+rH2hMLBcK6S1nJts1mYRprk=",
       "devOptional": true,
       "license": "MIT",
@@ -5268,7 +5274,7 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha1-pS+AvzjaGVLrXGgXkHGYcaGnJQE=",
       "license": "MIT",
       "optional": true,
@@ -5281,7 +5287,7 @@
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ieee754/-/ieee754-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I=",
       "funding": [
         {
@@ -5301,7 +5307,7 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "license": "MIT",
       "optional": true,
@@ -5311,7 +5317,7 @@
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/indent-string/-/indent-string-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE=",
       "license": "MIT",
       "optional": true,
@@ -5321,7 +5327,7 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "devOptional": true,
@@ -5333,13 +5339,13 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/inherits/-/inherits-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
       "license": "ISC"
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ip-address/-/ip-address-10.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha1-gF/BeLIMUYvUyFSLJP4wiS1/MgY=",
       "license": "MIT",
       "optional": true,
@@ -5349,7 +5355,7 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
       "license": "MIT",
       "engines": {
@@ -5358,14 +5364,14 @@
     },
     "node_modules/is-lambda": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-lambda/-/is-lambda-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
       "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=",
       "license": "MIT",
       "optional": true
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-stream/-/is-stream-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha1-+sHj1TuXrVqdCunO8jifWBClwHc=",
       "license": "MIT",
       "engines": {
@@ -5377,13 +5383,13 @@
     },
     "node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "license": "MIT"
     },
     "node_modules/isbinaryfile": {
       "version": "5.0.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
       "integrity": "sha1-Gac/IoG3No3KnTs6yKBDQHRnCXk=",
       "dev": true,
       "license": "MIT",
@@ -5396,7 +5402,7 @@
     },
     "node_modules/isexe": {
       "version": "3.1.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/isexe/-/isexe-3.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
       "integrity": "sha1-QuNo9o1eENrf7k/ae1ULwtiJLck=",
       "devOptional": true,
       "license": "BlueOak-1.0.0",
@@ -5406,7 +5412,7 @@
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jackspeak/-/jackspeak-3.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha1-iDOp2Jq0rN5hiJQr0cU7Y5DtWoo=",
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -5421,7 +5427,7 @@
     },
     "node_modules/jake": {
       "version": "10.9.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jake/-/jake-10.9.4.tgz",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
       "integrity": "sha1-1ibaEIxj1c+wCrXCX63H4AhK+OY=",
       "dev": true,
       "license": "Apache-2.0",
@@ -5439,7 +5445,7 @@
     },
     "node_modules/jiti": {
       "version": "2.7.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jiti/-/jiti-2.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha1-l0Io8vTKK8IYhaF5e0X+po6VDGQ=",
       "dev": true,
       "license": "MIT",
@@ -5449,7 +5455,7 @@
     },
     "node_modules/js-yaml": {
       "version": "4.3.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
       "integrity": "sha1-0ZAFcqf3zwtfVAyDZz5gutNDZZI=",
       "dev": true,
       "funding": [
@@ -5472,27 +5478,27 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-buffer/-/json-buffer-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json5/-/json5-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha1-eM1vGhm9wStz21rQxh79ZsHikoM=",
       "dev": true,
       "license": "MIT",
@@ -5505,7 +5511,7 @@
     },
     "node_modules/jsonfile": {
       "version": "6.2.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsonfile/-/jsonfile-6.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha1-tuMXF/Isw3MwsIHOAFHtXeU68vY=",
       "dev": true,
       "license": "MIT",
@@ -5518,7 +5524,7 @@
     },
     "node_modules/keyv": {
       "version": "4.5.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/keyv/-/keyv-4.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha1-qHmpnilFL5QkOfKkBeOvizHU3pM=",
       "dev": true,
       "license": "MIT",
@@ -5528,7 +5534,7 @@
     },
     "node_modules/koffi": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/koffi/-/koffi-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-3.1.1.tgz",
       "integrity": "sha1-JcYMv5sPFKbkVqfYUHjXSK991Bk=",
       "hasInstallScript": true,
       "license": "MIT",
@@ -5555,14 +5561,14 @@
     },
     "node_modules/lazy-val": {
       "version": "1.0.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lazy-val/-/lazy-val-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha1-bPO59bwxzufuPjacCDK3WD3Nkj0=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lazystream": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lazystream/-/lazystream-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
       "integrity": "sha1-SUyDEGLx+UCCUexE2xy6KSQqJjg=",
       "license": "MIT",
       "dependencies": {
@@ -5574,7 +5580,7 @@
     },
     "node_modules/lazystream/node_modules/readable-stream": {
       "version": "2.3.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/readable-stream/-/readable-stream-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha1-kRJegEK7obmIf0k0X2J3Anzovps=",
       "license": "MIT",
       "dependencies": {
@@ -5589,13 +5595,13 @@
     },
     "node_modules/lazystream/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "license": "MIT"
     },
     "node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "license": "MIT",
       "dependencies": {
@@ -5604,7 +5610,7 @@
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss/-/lightningcss-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha1-uFqulkhtyxv0mnyFcSISc/Tx5Kk=",
       "dev": true,
       "license": "MPL-2.0",
@@ -5634,7 +5640,7 @@
     },
     "node_modules/lightningcss-android-arm64": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
       "integrity": "sha1-8DOIURbf79nG9UeHUj41FLYeGWg=",
       "cpu": [
         "arm64"
@@ -5655,7 +5661,7 @@
     },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
       "integrity": "sha1-ULcYcbAcgZlYS2SeKSVH+up6+bU=",
       "cpu": [
         "arm64"
@@ -5676,7 +5682,7 @@
     },
     "node_modules/lightningcss-darwin-x64": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
       "integrity": "sha1-NfPpczLRMLnKGB4RtWje1q68bV4=",
       "cpu": [
         "x64"
@@ -5697,7 +5703,7 @@
     },
     "node_modules/lightningcss-freebsd-x64": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
       "integrity": "sha1-l3enZHK2Ttb/lDQq1kx7r9eUpXU=",
       "cpu": [
         "x64"
@@ -5718,7 +5724,7 @@
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
       "integrity": "sha1-E65lLhq3O5E117faFy9mbEEK1T0=",
       "cpu": [
         "arm"
@@ -5739,7 +5745,7 @@
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
       "integrity": "sha1-QXhYeVqUWS9oASOhsfnaig4e8zU=",
       "cpu": [
         "arm64"
@@ -5760,7 +5766,7 @@
     },
     "node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
       "integrity": "sha1-a+NmkugQtxgECAL9gJYjz/5zITM=",
       "cpu": [
         "arm64"
@@ -5781,7 +5787,7 @@
     },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
       "integrity": "sha1-C3gDr06yHP043Tn+Kru1PH3QkfY=",
       "cpu": [
         "x64"
@@ -5802,7 +5808,7 @@
     },
     "node_modules/lightningcss-linux-x64-musl": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
       "integrity": "sha1-iNyLqGXd3bGsXvBLDxYYBEGMFjs=",
       "cpu": [
         "x64"
@@ -5823,7 +5829,7 @@
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
       "integrity": "sha1-TzC6P6XpJfW3n5RejMDRdsOxqzg=",
       "cpu": [
         "arm64"
@@ -5844,7 +5850,7 @@
     },
     "node_modules/lightningcss-win32-x64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
       "integrity": "sha1-FBqlYFZFBkkokCu0rwRfp9n0Igo=",
       "cpu": [
         "x64"
@@ -5865,7 +5871,7 @@
     },
     "node_modules/local-pkg": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/local-pkg/-/local-pkg-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
       "integrity": "sha1-lig4k5mFHXjztQySNu3bAvDDGys=",
       "dev": true,
       "license": "MIT",
@@ -5883,19 +5889,19 @@
     },
     "node_modules/lodash": {
       "version": "4.18.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash/-/lodash-4.18.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha1-/ytmwfYybVlRPeJAe/iBQ5gSdxw=",
       "license": "MIT"
     },
     "node_modules/long": {
       "version": "5.3.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/long/-/long-5.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha1-HYRGMJWZkmLX17f4v9SozFUWf4M=",
       "license": "Apache-2.0"
     },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha1-JgPni3tLAAbLyi+8yKMgJVislHk=",
       "dev": true,
       "license": "MIT",
@@ -5905,7 +5911,7 @@
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-cache/-/lru-cache-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
       "dev": true,
       "license": "ISC",
@@ -5918,7 +5924,7 @@
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/make-dir/-/make-dir-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha1-QV6WcEazp/HRhSd9hKpYIDcmoT8=",
       "license": "MIT",
       "optional": true,
@@ -5934,7 +5940,7 @@
     },
     "node_modules/make-dir/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-6.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha1-VW0u+GiRRuRtzqS/3QlfNDTf/LQ=",
       "license": "ISC",
       "optional": true,
@@ -5944,7 +5950,7 @@
     },
     "node_modules/make-fetch-happen": {
       "version": "13.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz",
       "integrity": "sha1-Jzui949F4fOm3Kkc7eh9n6SCHjY=",
       "license": "ISC",
       "optional": true,
@@ -5968,7 +5974,7 @@
     },
     "node_modules/make-fetch-happen/node_modules/proc-log": {
       "version": "4.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/proc-log/-/proc-log-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
       "integrity": "sha1-tvRh5AJudf3+IosmXp96AHedcDQ=",
       "license": "ISC",
       "optional": true,
@@ -5978,7 +5984,7 @@
     },
     "node_modules/matcher": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/matcher/-/matcher-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
       "integrity": "sha1-vZBg9MW3CqgEHMxvgDaHYJlPMMo=",
       "license": "MIT",
       "dependencies": {
@@ -5990,7 +5996,7 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha1-oN10voHiqlwvJ+Zc4oNgXuTit/k=",
       "dev": true,
       "license": "MIT",
@@ -6000,7 +6006,7 @@
     },
     "node_modules/mime": {
       "version": "2.6.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mime/-/mime-2.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
       "integrity": "sha1-oqaCqVzU0MsdYlfij4PafjWAA2c=",
       "dev": true,
       "license": "MIT",
@@ -6013,7 +6019,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A=",
       "dev": true,
       "license": "MIT",
@@ -6023,7 +6029,7 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mime-types/-/mime-types-2.1.35.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=",
       "dev": true,
       "license": "MIT",
@@ -6036,7 +6042,7 @@
     },
     "node_modules/mimic-response": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mimic-response/-/mimic-response-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha1-SSNTiHju9CBjy4o+OweYeBSHqxs=",
       "dev": true,
       "license": "MIT",
@@ -6046,7 +6052,7 @@
     },
     "node_modules/minimatch": {
       "version": "10.2.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-10.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha1-vUhoegvjjtKWE5kQVgD4MglYYdE=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -6062,7 +6068,7 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimist/-/minimist-1.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha1-waRk52kzAuCCoHXO4MBXdBrEdyw=",
       "dev": true,
       "license": "MIT",
@@ -6072,7 +6078,7 @@
     },
     "node_modules/minipass": {
       "version": "7.1.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-7.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha1-eTibTrG7LQA6m7qH1JLyvTe9xls=",
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -6081,7 +6087,7 @@
     },
     "node_modules/minipass-collect": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass-collect/-/minipass-collect-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
       "integrity": "sha1-FiG8d+EiWKEsYNNOInbsXCBoCGM=",
       "license": "ISC",
       "optional": true,
@@ -6094,7 +6100,7 @@
     },
     "node_modules/minipass-fetch": {
       "version": "3.0.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass-fetch/-/minipass-fetch-3.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.5.tgz",
       "integrity": "sha1-8Pl+QFgK/8SjXMShNJ8FrjbLHkw=",
       "license": "MIT",
       "optional": true,
@@ -6112,7 +6118,7 @@
     },
     "node_modules/minipass-fetch/node_modules/minizlib": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minizlib/-/minizlib-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha1-6Q00Zrogm5MkUVCKEc49NjIUWTE=",
       "license": "MIT",
       "optional": true,
@@ -6126,7 +6132,7 @@
     },
     "node_modules/minipass-fetch/node_modules/minizlib/node_modules/minipass": {
       "version": "3.3.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-3.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha1-e7o4TbOhUg0YycDlJRw0ROld2Uo=",
       "license": "ISC",
       "optional": true,
@@ -6139,7 +6145,7 @@
     },
     "node_modules/minipass-flush": {
       "version": "1.0.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
       "integrity": "sha1-FFw4PVrilLNgMKqA1Ohy0Ivry3M=",
       "license": "BlueOak-1.0.0",
       "optional": true,
@@ -6152,7 +6158,7 @@
     },
     "node_modules/minipass-flush/node_modules/minipass": {
       "version": "3.3.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-3.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha1-e7o4TbOhUg0YycDlJRw0ROld2Uo=",
       "license": "ISC",
       "optional": true,
@@ -6165,7 +6171,7 @@
     },
     "node_modules/minipass-pipeline": {
       "version": "1.2.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
       "integrity": "sha1-aEcveXEcCEZXwGfFxq2Tzd6oIUw=",
       "license": "ISC",
       "optional": true,
@@ -6178,7 +6184,7 @@
     },
     "node_modules/minipass-pipeline/node_modules/minipass": {
       "version": "3.3.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-3.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha1-e7o4TbOhUg0YycDlJRw0ROld2Uo=",
       "license": "ISC",
       "optional": true,
@@ -6191,7 +6197,7 @@
     },
     "node_modules/minipass-sized": {
       "version": "1.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
       "integrity": "sha1-cO5afFBSBwr6z7wil36nne81O3A=",
       "license": "ISC",
       "optional": true,
@@ -6204,7 +6210,7 @@
     },
     "node_modules/minipass-sized/node_modules/minipass": {
       "version": "3.3.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-3.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha1-e7o4TbOhUg0YycDlJRw0ROld2Uo=",
       "license": "ISC",
       "optional": true,
@@ -6217,7 +6223,7 @@
     },
     "node_modules/minizlib": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minizlib/-/minizlib-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
       "integrity": "sha1-atdsOo8QInybUdHJrI4wsn9aJRw=",
       "dev": true,
       "license": "MIT",
@@ -6230,7 +6236,7 @@
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mkdirp/-/mkdirp-0.5.6.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha1-fe8D0kMtyuS6HWEURcSDlgYiVfY=",
       "dev": true,
       "license": "MIT",
@@ -6244,7 +6250,7 @@
     },
     "node_modules/mlly": {
       "version": "1.8.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mlly/-/mlly-1.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
       "integrity": "sha1-5/eRmoLROxdEBWExFySaP0SdeLs=",
       "dev": true,
       "license": "MIT",
@@ -6257,14 +6263,14 @@
     },
     "node_modules/mlly/node_modules/confbox": {
       "version": "0.1.8",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/confbox/-/confbox-0.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
       "integrity": "sha1-gg1z07PILZvZEGUsXU1Znvj/iwY=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/mlly/node_modules/pkg-types": {
       "version": "1.3.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pkg-types/-/pkg-types-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
       "integrity": "sha1-vXzHCIEZJ3fu9TJsGd60bokJF98=",
       "dev": true,
       "license": "MIT",
@@ -6276,14 +6282,14 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.16",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nanoid/-/nanoid-3.3.16.tgz",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
       "integrity": "sha1-oE2OxLHxAAnS1TOUeu/kKTc3gWw=",
       "dev": true,
       "funding": [
@@ -6302,7 +6308,7 @@
     },
     "node_modules/negotiator": {
       "version": "0.6.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/negotiator/-/negotiator-0.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
       "integrity": "sha1-d3lI4kUmUcVwtxLdAcI+JicT//c=",
       "license": "MIT",
       "optional": true,
@@ -6312,7 +6318,7 @@
     },
     "node_modules/node-abi": {
       "version": "4.33.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-abi/-/node-abi-4.33.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.33.0.tgz",
       "integrity": "sha1-zOm3vODL+h1dWptpCLxe7WmJacw=",
       "dev": true,
       "license": "MIT",
@@ -6325,7 +6331,7 @@
     },
     "node_modules/node-addon-api": {
       "version": "8.9.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-addon-api/-/node-addon-api-8.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
       "integrity": "sha1-0kZwkOYZXEKMzVEN/WBPAcAn8KA=",
       "license": "MIT",
       "optional": true,
@@ -6335,7 +6341,7 @@
     },
     "node_modules/node-api-version": {
       "version": "0.2.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-api-version/-/node-api-version-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
       "integrity": "sha1-GbrVT21lYoy+5OYHoyXkSIrOLek=",
       "dev": true,
       "license": "MIT",
@@ -6345,7 +6351,7 @@
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-fetch/-/node-fetch-2.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha1-0PD6bj4twdJ+/NitmdVQvalNGH0=",
       "license": "MIT",
       "optional": true,
@@ -6366,7 +6372,7 @@
     },
     "node_modules/node-gyp": {
       "version": "12.4.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-gyp/-/node-gyp-12.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
       "integrity": "sha1-LQF7bqHKkpTbvudb5TNyj0klcCQ=",
       "dev": true,
       "license": "MIT",
@@ -6391,7 +6397,7 @@
     },
     "node_modules/node-gyp/node_modules/abbrev": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/abbrev/-/abbrev-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
       "integrity": "sha1-7JM/Die2zWDom1xrKjBK9CIJuwU=",
       "dev": true,
       "license": "ISC",
@@ -6401,7 +6407,7 @@
     },
     "node_modules/node-gyp/node_modules/env-paths": {
       "version": "2.2.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/env-paths/-/env-paths-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha1-QgOZ1BbOH76bwKB8Yvpo1n/Q+PI=",
       "dev": true,
       "license": "MIT",
@@ -6411,7 +6417,7 @@
     },
     "node_modules/node-gyp/node_modules/isexe": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/isexe/-/isexe-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
       "integrity": "sha1-SPZXavjoehj+t5a37V4uWQO0Pco=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -6421,7 +6427,7 @@
     },
     "node_modules/node-gyp/node_modules/nopt": {
       "version": "9.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nopt/-/nopt-9.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
       "integrity": "sha1-a/8INrKWTSRQi2tBtamknE9KH5Y=",
       "dev": true,
       "license": "ISC",
@@ -6437,7 +6443,7 @@
     },
     "node_modules/node-gyp/node_modules/undici": {
       "version": "6.27.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/undici/-/undici-6.27.0.tgz",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
       "integrity": "sha1-Qfnkj3xaQNJzdsqurYyan8e8qcQ=",
       "dev": true,
       "license": "MIT",
@@ -6447,7 +6453,7 @@
     },
     "node_modules/node-gyp/node_modules/which": {
       "version": "6.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/which/-/which-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
       "integrity": "sha1-AhZCRDoZj7k7eEpWBnIcsYz8v84=",
       "dev": true,
       "license": "ISC",
@@ -6463,14 +6469,14 @@
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-int64/-/node-int64-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nopt": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nopt/-/nopt-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
       "integrity": "sha1-UwlCu1ilEvzK/lP+IQ8TolNV3Ig=",
       "license": "ISC",
       "optional": true,
@@ -6486,7 +6492,7 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/normalize-path/-/normalize-path-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
       "license": "MIT",
       "engines": {
@@ -6495,7 +6501,7 @@
     },
     "node_modules/normalize-url": {
       "version": "6.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/normalize-url/-/normalize-url-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha1-QNCIW1Nd7/4/MUe+yHfQX+TFZoo=",
       "dev": true,
       "license": "MIT",
@@ -6508,7 +6514,7 @@
     },
     "node_modules/npmlog": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/npmlog/-/npmlog-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
       "integrity": "sha1-8GZ46A4pQZrWerlk4PpplZweuLA=",
       "deprecated": "This package is no longer supported.",
       "license": "ISC",
@@ -6522,7 +6528,7 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "license": "MIT",
       "optional": true,
@@ -6532,7 +6538,7 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/object-keys/-/object-keys-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
       "license": "MIT",
       "engines": {
@@ -6541,7 +6547,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "devOptional": true,
       "license": "ISC",
@@ -6551,13 +6557,13 @@
     },
     "node_modules/onnxruntime-common": {
       "version": "1.24.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
       "integrity": "sha1-+5Mxmi0EH8n+KiCRZ7pu8vGkf+4=",
       "license": "MIT"
     },
     "node_modules/onnxruntime-node": {
       "version": "1.24.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/onnxruntime-node/-/onnxruntime-node-1.24.3.tgz",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.24.3.tgz",
       "integrity": "sha1-7I2pnDNapeqVVZo6wa6RWolUHV4=",
       "hasInstallScript": true,
       "license": "MIT",
@@ -6574,7 +6580,7 @@
     },
     "node_modules/onnxruntime-web": {
       "version": "1.26.0-dev.20260416-b7804b056c",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/onnxruntime-web/-/onnxruntime-web-1.26.0-dev.20260416-b7804b056c.tgz",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.26.0-dev.20260416-b7804b056c.tgz",
       "integrity": "sha1-RT8pdog2Mipri20dcwqEJrZYKuI=",
       "license": "MIT",
       "dependencies": {
@@ -6588,13 +6594,13 @@
     },
     "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
       "version": "1.24.0-dev.20251116-b39e144322",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/onnxruntime-common/-/onnxruntime-common-1.24.0-dev.20251116-b39e144322.tgz",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.0-dev.20251116-b39e144322.tgz",
       "integrity": "sha1-bt7PTlF4+ddpB9WrviQcNjXlKN0=",
       "license": "MIT"
     },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
       "integrity": "sha1-qrf71BZYL6MqPbSYWcEiSHxe0s8=",
       "dev": true,
       "license": "MIT",
@@ -6604,7 +6610,7 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-limit/-/p-limit-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
       "dev": true,
       "license": "MIT",
@@ -6620,7 +6626,7 @@
     },
     "node_modules/p-map": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-map/-/p-map-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
       "integrity": "sha1-uy+Vpe2i7BaOySdOBqdHw+KQTSs=",
       "license": "MIT",
       "optional": true,
@@ -6636,13 +6642,13 @@
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha1-TxRxoBCCeob5TP2bByfjbSZ95QU=",
       "license": "BlueOak-1.0.0"
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "devOptional": true,
       "license": "MIT",
@@ -6652,7 +6658,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-key/-/path-key-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
       "license": "MIT",
       "engines": {
@@ -6661,7 +6667,7 @@
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-scurry/-/path-scurry-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha1-eWCmaIiFlKByCxKpEdGnQqufEdI=",
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -6677,20 +6683,20 @@
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
       "version": "10.4.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-cache/-/lru-cache-10.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha1-QQ/IoXtw5ZgBPfJXwkRrfzOD8Rk=",
       "license": "ISC"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pathe/-/pathe-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha1-PsvsVUIWhbcKnahyss/z4cvtFxY=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/pe-library": {
       "version": "0.4.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pe-library/-/pe-library-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
       "integrity": "sha1-4mm+A0DcsTqmlJ10PafWWMPi++o=",
       "dev": true,
       "license": "MIT",
@@ -6705,14 +6711,14 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picocolors/-/picocolors-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha1-PTIa8+q5ObCDyPkpodEs2oHCa2s=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picomatch/-/picomatch-4.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha1-UepXoX2G9gX4EDlZX7xA7QalX6s=",
       "dev": true,
       "license": "MIT",
@@ -6725,7 +6731,7 @@
     },
     "node_modules/pkg-types": {
       "version": "2.3.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pkg-types/-/pkg-types-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
       "integrity": "sha1-+iftCUDvz0C7pFOw5cq0Ehew1EI=",
       "dev": true,
       "license": "MIT",
@@ -6737,7 +6743,7 @@
     },
     "node_modules/pkijs": {
       "version": "3.4.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pkijs/-/pkijs-3.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
       "integrity": "sha1-2RZN7zD/bZe+LYiWbV42GSSZypw=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -6755,7 +6761,7 @@
     },
     "node_modules/pkijs/node_modules/@noble/hashes": {
       "version": "1.4.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@noble/hashes/-/hashes-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
       "integrity": "sha1-RYFKoynzDk/guklCb0nfzN0GZCY=",
       "dev": true,
       "license": "MIT",
@@ -6768,13 +6774,13 @@
     },
     "node_modules/platform": {
       "version": "1.3.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/platform/-/platform-1.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha1-SLTOmDFksgnC1FoQetsx9HOm56c=",
       "license": "MIT"
     },
     "node_modules/plist": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/plist/-/plist-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
       "integrity": "sha1-eXpRapPmL1veVeC5zJyWf4YIk8k=",
       "dev": true,
       "license": "MIT",
@@ -6789,7 +6795,7 @@
     },
     "node_modules/postcss": {
       "version": "8.5.19",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss/-/postcss-8.5.19.tgz",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
       "integrity": "sha1-Ra1c/eSZQI4gFHNII3VROBqSIDc=",
       "dev": true,
       "funding": [
@@ -6818,7 +6824,7 @@
     },
     "node_modules/postject": {
       "version": "1.0.0-alpha.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postject/-/postject-1.0.0-alpha.6.tgz",
+      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
       "integrity": "sha1-nQIjMicuLPzo3qTPzh7m3Rsu4TU=",
       "dev": true,
       "license": "MIT",
@@ -6836,7 +6842,7 @@
     },
     "node_modules/postject/node_modules/commander": {
       "version": "9.5.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/commander/-/commander-9.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
       "integrity": "sha1-vAjR61zt98y3l6lhmdQce8PmDTA=",
       "dev": true,
       "license": "MIT",
@@ -6848,7 +6854,7 @@
     },
     "node_modules/proc-log": {
       "version": "6.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/proc-log/-/proc-log-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
       "integrity": "sha1-GFGUgqN9UZjiMRM6cBRKUPIfAhU=",
       "dev": true,
       "license": "ISC",
@@ -6858,7 +6864,7 @@
     },
     "node_modules/process": {
       "version": "0.11.10",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/process/-/process-0.11.10.tgz",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "license": "MIT",
       "engines": {
@@ -6867,13 +6873,13 @@
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
       "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/progress/-/progress-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg=",
       "dev": true,
       "license": "MIT",
@@ -6883,7 +6889,7 @@
     },
     "node_modules/promise-retry": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/promise-retry/-/promise-retry-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
       "integrity": "sha1-/3R6E2IKtXumiPX8Z4VUEMNw2iI=",
       "devOptional": true,
       "license": "MIT",
@@ -6897,7 +6903,7 @@
     },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
       "integrity": "sha1-yLneKvay8WAQZ/mOAaxmuqIjFB8=",
       "dev": true,
       "license": "MIT",
@@ -6909,7 +6915,7 @@
     },
     "node_modules/protobufjs": {
       "version": "7.6.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/protobufjs/-/protobufjs-7.6.5.tgz",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
       "integrity": "sha1-e5JQza9KBhOanw/kaKQNfU/rynE=",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -6932,7 +6938,7 @@
     },
     "node_modules/pump": {
       "version": "3.0.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pump/-/pump-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha1-HzE0MFJ/qLkFYi69Iv4UROdXqzw=",
       "dev": true,
       "license": "MIT",
@@ -6943,7 +6949,7 @@
     },
     "node_modules/pvtsutils": {
       "version": "1.3.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
       "integrity": "sha1-7EbjTbdCK55P3FSQV4wYg2V9YAE=",
       "dev": true,
       "license": "MIT",
@@ -6953,7 +6959,7 @@
     },
     "node_modules/pvutils": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pvutils/-/pvutils-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
       "integrity": "sha1-hLDepKXWcCSaqYAFEYBO4LfCgJw=",
       "dev": true,
       "license": "MIT",
@@ -6963,7 +6969,7 @@
     },
     "node_modules/quansync": {
       "version": "0.2.11",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/quansync/-/quansync-0.2.11.tgz",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
       "integrity": "sha1-+cOt2i4ScuT4zz8UV7BMvbTuaSo=",
       "dev": true,
       "funding": [
@@ -6980,7 +6986,7 @@
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/quick-lru/-/quick-lru-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha1-NmST5rPkKjpoheLpnRj4D7eoyTI=",
       "dev": true,
       "license": "MIT",
@@ -6993,7 +6999,7 @@
     },
     "node_modules/react": {
       "version": "19.2.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react/-/react-19.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha1-H0ehv8BvjsiFdSxvSvFDaan4Jgs=",
       "license": "MIT",
       "engines": {
@@ -7002,7 +7008,7 @@
     },
     "node_modules/react-dom": {
       "version": "19.2.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-dom/-/react-dom-19.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha1-BFDcmundv/du8ZZAHNi4x/tGbMw=",
       "license": "MIT",
       "dependencies": {
@@ -7014,7 +7020,7 @@
     },
     "node_modules/read-binary-file-arch": {
       "version": "1.0.6",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
       "integrity": "sha1-lZxGN9qpMigKm5EbGmdmp+RCiPw=",
       "dev": true,
       "license": "MIT",
@@ -7027,7 +7033,7 @@
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/readable-stream/-/readable-stream-3.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha1-VqmzbqllwAxak+8x6xEaDxEFaWc=",
       "license": "MIT",
       "optional": true,
@@ -7042,7 +7048,7 @@
     },
     "node_modules/readdir-glob": {
       "version": "1.1.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
       "integrity": "sha1-w9gx9R9ee/pi+i/75LUIxkDwlYQ=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7051,13 +7057,13 @@
     },
     "node_modules/readdir-glob/node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "license": "MIT"
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
       "integrity": "sha1-C7oicf631Fiw0xrRNiWqpHVEMeI=",
       "license": "MIT",
       "dependencies": {
@@ -7066,7 +7072,7 @@
     },
     "node_modules/readdir-glob/node_modules/minimatch": {
       "version": "5.1.9",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-5.1.9.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
       "integrity": "sha1-EpPvFdsAmLOUVA6Pn3RPn9qN7ks=",
       "license": "ISC",
       "dependencies": {
@@ -7078,7 +7084,7 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true,
       "license": "MIT",
@@ -7088,7 +7094,7 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/require-from-string/-/require-from-string-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha1-iaf92TgmEmcxjq/hT5wy5ZjDaQk=",
       "dev": true,
       "license": "MIT",
@@ -7098,7 +7104,7 @@
     },
     "node_modules/resedit": {
       "version": "1.7.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/resedit/-/resedit-1.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz",
       "integrity": "sha1-sQQRcLmYEXEME/lJx9Ilhx3kzHg=",
       "dev": true,
       "license": "MIT",
@@ -7116,14 +7122,14 @@
     },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha1-t629rDVGqq7CC0Xn2CZZJwcnJvk=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/responselike": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/responselike/-/responselike-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
       "integrity": "sha1-mgvI/cJS8/scymiwFlkQWboUIrw=",
       "dev": true,
       "license": "MIT",
@@ -7136,7 +7142,7 @@
     },
     "node_modules/retry": {
       "version": "0.12.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/retry/-/retry-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "devOptional": true,
       "license": "MIT",
@@ -7146,7 +7152,7 @@
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rimraf/-/rimraf-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "license": "ISC",
@@ -7163,7 +7169,7 @@
     },
     "node_modules/roarr": {
       "version": "2.15.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/roarr/-/roarr-2.15.4.tgz",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
       "integrity": "sha1-9f55W3uDjM/jXcYI4Cgrnrouev0=",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -7180,7 +7186,7 @@
     },
     "node_modules/rolldown": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rolldown/-/rolldown-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
       "integrity": "sha1-M5quJQhENR/FW3TiZS0+vW+6OJ0=",
       "dev": true,
       "license": "MIT",
@@ -7214,7 +7220,7 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
       "funding": [
         {
@@ -7234,14 +7240,14 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
       "license": "MIT",
       "optional": true
     },
     "node_modules/sanitize-filename": {
       "version": "1.6.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
       "integrity": "sha1-trOevtm9GhiYuFxcAwidp0WQ1vg=",
       "dev": true,
       "license": "WTFPL OR ISC",
@@ -7251,7 +7257,7 @@
     },
     "node_modules/sax": {
       "version": "1.6.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sax/-/sax-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
       "integrity": "sha1-2lljdikwe5fnxMso4ICnvDhWDVs=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -7261,13 +7267,13 @@
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/scheduler/-/scheduler-0.27.0.tgz",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha1-DE74LWfR5cHjWej8dtOofwRf5b0=",
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
       "license": "ISC",
       "bin": {
@@ -7279,13 +7285,13 @@
     },
     "node_modules/semver-compare": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver-compare/-/semver-compare-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
       "license": "MIT"
     },
     "node_modules/serialize-error": {
       "version": "7.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/serialize-error/-/serialize-error-7.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
       "integrity": "sha1-8TYLBEf2H/tIPsQVfHN/q313jhg=",
       "license": "MIT",
       "dependencies": {
@@ -7300,14 +7306,14 @@
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "license": "ISC",
       "optional": true
     },
     "node_modules/sharp": {
       "version": "0.34.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sharp/-/sharp-0.34.5.tgz",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
       "integrity": "sha1-tvFI5LjGHxeXveEanRz+u64sV7A=",
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -7351,7 +7357,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
       "license": "MIT",
       "dependencies": {
@@ -7363,7 +7369,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
       "license": "MIT",
       "engines": {
@@ -7372,14 +7378,14 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
       "devOptional": true,
       "license": "ISC"
     },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
       "integrity": "sha1-1wuSvat9bZDf1zkxGVowtuPXzrs=",
       "dev": true,
       "license": "MIT",
@@ -7392,7 +7398,7 @@
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha1-bh1x+k8YwF99D/IW3RakgdDo2a4=",
       "license": "MIT",
       "optional": true,
@@ -7403,7 +7409,7 @@
     },
     "node_modules/socks": {
       "version": "2.8.9",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/socks/-/socks-2.8.9.tgz",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
       "integrity": "sha1-ql8TDKD4ikP6RPr0hpxQ0iqid1I=",
       "license": "MIT",
       "optional": true,
@@ -7418,7 +7424,7 @@
     },
     "node_modules/socks-proxy-agent": {
       "version": "8.0.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
       "integrity": "sha1-uc205+mYUJ12WdaJznaXrCFkW+4=",
       "license": "MIT",
       "optional": true,
@@ -7433,7 +7439,7 @@
     },
     "node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/source-map/-/source-map-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -7443,7 +7449,7 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/source-map-js/-/source-map-js-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha1-HOVlD93YerwJnto33P8CTCZnrkY=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -7453,7 +7459,7 @@
     },
     "node_modules/source-map-support": {
       "version": "0.5.21",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/source-map-support/-/source-map-support-0.5.21.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha1-BP58f54e0tZiIzwoyys1ufY/bk8=",
       "dev": true,
       "license": "MIT",
@@ -7464,13 +7470,13 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha1-SRS5A6L4toXRf994pw6RfocuREo=",
       "license": "BSD-3-Clause"
     },
     "node_modules/ssri": {
       "version": "10.0.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ssri/-/ssri-10.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
       "integrity": "sha1-qKreLeYLorzoaI4/o0m60Fx9weU=",
       "license": "ISC",
       "optional": true,
@@ -7483,7 +7489,7 @@
     },
     "node_modules/stat-mode": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/stat-mode/-/stat-mode-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
       "integrity": "sha1-aLVcth6mOf9XE282shaikYANFGU=",
       "dev": true,
       "license": "MIT",
@@ -7493,7 +7499,7 @@
     },
     "node_modules/streamx": {
       "version": "2.28.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/streamx/-/streamx-2.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
       "integrity": "sha1-A1q1YFe37SIRtR1TLmlz8PmfvxE=",
       "license": "MIT",
       "dependencies": {
@@ -7504,7 +7510,7 @@
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string_decoder/-/string_decoder-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
       "license": "MIT",
       "dependencies": {
@@ -7513,7 +7519,7 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
       "license": "MIT",
       "dependencies": {
@@ -7528,7 +7534,7 @@
     "node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
       "license": "MIT",
       "dependencies": {
@@ -7542,7 +7548,7 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
       "license": "MIT",
       "dependencies": {
@@ -7555,7 +7561,7 @@
     "node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
       "license": "MIT",
       "dependencies": {
@@ -7567,7 +7573,7 @@
     },
     "node_modules/sumchecker": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sumchecker/-/sumchecker-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
       "integrity": "sha1-Y3fplnlauwttNI6bPh37JDRajkI=",
       "dev": true,
       "license": "Apache-2.0",
@@ -7580,7 +7586,7 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/supports-color/-/supports-color-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
       "dev": true,
       "license": "MIT",
@@ -7593,7 +7599,7 @@
     },
     "node_modules/tar": {
       "version": "7.5.20",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tar/-/tar-7.5.20.tgz",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
       "integrity": "sha1-N6ZaqRHL1phkAC4Uv4qSalVR4kA=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -7610,7 +7616,7 @@
     },
     "node_modules/tar-stream": {
       "version": "3.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tar-stream/-/tar-stream-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
       "integrity": "sha1-DQBk2bZ+o8n1q94VXjX6qw3zdZE=",
       "license": "MIT",
       "dependencies": {
@@ -7622,7 +7628,7 @@
     },
     "node_modules/tar/node_modules/yallist": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yallist/-/yallist-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
       "integrity": "sha1-AOLeRDY57Q14/YfeDSdGn7z/tTM=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -7632,7 +7638,7 @@
     },
     "node_modules/teex": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/teex/-/teex-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
       "integrity": "sha1-uPpyRe+Ojv+oB4KBlGyFq3gKCxI=",
       "license": "MIT",
       "dependencies": {
@@ -7641,7 +7647,7 @@
     },
     "node_modules/temp": {
       "version": "0.9.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/temp/-/temp-0.9.4.tgz",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
       "integrity": "sha1-zSCoWAy2NjXQ5OnUvZidRChudiA=",
       "dev": true,
       "license": "MIT",
@@ -7656,7 +7662,7 @@
     },
     "node_modules/temp-file": {
       "version": "3.4.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/temp-file/-/temp-file-3.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz",
       "integrity": "sha1-dm6iiRHGg5lsJI7xog7qBNUWUsc=",
       "dev": true,
       "license": "MIT",
@@ -7667,7 +7673,7 @@
     },
     "node_modules/temp/node_modules/rimraf": {
       "version": "2.6.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rimraf/-/rimraf-2.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
@@ -7682,7 +7688,7 @@
     },
     "node_modules/text-decoder": {
       "version": "1.2.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/text-decoder/-/text-decoder-1.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
       "integrity": "sha1-XQc6mnS5wKnSjfrcq5a2BK9X2Lo=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7691,7 +7697,7 @@
     },
     "node_modules/tiny-async-pool": {
       "version": "1.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tiny-async-pool/-/tiny-async-pool-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.3.0.tgz",
       "integrity": "sha1-wBPhs2kJXnAF21WV+V5kbMpu+KU=",
       "dev": true,
       "license": "MIT",
@@ -7701,7 +7707,7 @@
     },
     "node_modules/tiny-async-pool/node_modules/semver": {
       "version": "5.7.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-5.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg=",
       "dev": true,
       "license": "ISC",
@@ -7711,7 +7717,7 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha1-ViqabJ6ys7Ej05cZ+a9btE/NdjE=",
       "dev": true,
       "license": "MIT",
@@ -7728,7 +7734,7 @@
     },
     "node_modules/tmp": {
       "version": "0.2.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tmp/-/tmp-0.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
       "integrity": "sha1-JvTbEdFgHOgBLcuKeY7OHAapkFk=",
       "dev": true,
       "license": "MIT",
@@ -7738,7 +7744,7 @@
     },
     "node_modules/tmp-promise": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
       "integrity": "sha1-YKGhzJjJiGdPy/0jtuM2e96sTOc=",
       "dev": true,
       "license": "MIT",
@@ -7748,14 +7754,14 @@
     },
     "node_modules/tr46": {
       "version": "0.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tr46/-/tr46-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
       "license": "MIT",
       "optional": true
     },
     "node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
       "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
       "dev": true,
       "license": "WTFPL",
@@ -7765,14 +7771,14 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tslib/-/tslib-2.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/type-fest": {
       "version": "0.13.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/type-fest/-/type-fest-0.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
       "integrity": "sha1-AXLLW86AsL1ULqNI21DH4hg02TQ=",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
@@ -7784,7 +7790,7 @@
     },
     "node_modules/typescript": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript/-/typescript-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
       "integrity": "sha1-nsdz15VKjBgsF8xbvVdaoovFFYI=",
       "dev": true,
       "license": "Apache-2.0",
@@ -7819,14 +7825,14 @@
     },
     "node_modules/ufo": {
       "version": "1.6.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ufo/-/ufo-1.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
       "integrity": "sha1-eo+4dfzGOC0sfQs2knOLBQCpJGc=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.28.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/undici/-/undici-7.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
       "integrity": "sha1-l9ZFZBmLKFvCgfDo4pWX49Ef5+w=",
       "dev": true,
       "license": "MIT",
@@ -7837,13 +7843,13 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/undici-types/-/undici-types-6.21.0.tgz",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha1-aR0ArzkJvpOn+qE75hs6W1DvEss=",
       "license": "MIT"
     },
     "node_modules/unique-filename": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unique-filename/-/unique-filename-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
       "integrity": "sha1-SLp6WhaEn1CA0mx2DIbPXPBXcOo=",
       "license": "ISC",
       "optional": true,
@@ -7856,7 +7862,7 @@
     },
     "node_modules/unique-slug": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unique-slug/-/unique-slug-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
       "integrity": "sha1-a65rsWvpE1G63STNznQfiSplMuM=",
       "license": "ISC",
       "optional": true,
@@ -7869,7 +7875,7 @@
     },
     "node_modules/universalify": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/universalify/-/universalify-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha1-Fo78IYCWTmOG0GHglN9hr+I5sY0=",
       "dev": true,
       "license": "MIT",
@@ -7879,7 +7885,7 @@
     },
     "node_modules/unzipper": {
       "version": "0.12.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unzipper/-/unzipper-0.12.5.tgz",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.5.tgz",
       "integrity": "sha1-f8a0hi84MiAtH1zDrb7iZ53qr2w=",
       "dev": true,
       "license": "MIT",
@@ -7893,7 +7899,7 @@
     },
     "node_modules/unzipper/node_modules/fs-extra": {
       "version": "11.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fs-extra/-/fs-extra-11.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
       "integrity": "sha1-unofl6hflMbbLlL/aVcNs2cdWnQ=",
       "dev": true,
       "license": "MIT",
@@ -7908,20 +7914,20 @@
     },
     "node_modules/utf8-byte-length": {
       "version": "1.0.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
       "integrity": "sha1-+fY5ENFVNu4rLV3UZlOJcV6sXB4=",
       "dev": true,
       "license": "(WTFPL OR MIT)"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.1.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vite/-/vite-8.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
       "integrity": "sha1-zP/OPuSHsYhiI7JOuye5FnSCfTA=",
       "dev": true,
       "license": "MIT",
@@ -7999,7 +8005,7 @@
     },
     "node_modules/vite-plugin-electron": {
       "version": "1.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vite-plugin-electron/-/vite-plugin-electron-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/vite-plugin-electron/-/vite-plugin-electron-1.0.4.tgz",
       "integrity": "sha1-YKVDbScXE5xNMRaoqxBxU/MGk44=",
       "dev": true,
       "license": "MIT",
@@ -8017,7 +8023,7 @@
     },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
       "integrity": "sha1-oyLMDx2X95T/2cTNKomKC94JfzQ=",
       "license": "MIT",
       "engines": {
@@ -8026,7 +8032,7 @@
     },
     "node_modules/webcrypto-core": {
       "version": "1.9.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/webcrypto-core/-/webcrypto-core-1.9.2.tgz",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.9.2.tgz",
       "integrity": "sha1-It1qD7VSF7EwHqtxUdAdXGjlLMs=",
       "dev": true,
       "license": "MIT",
@@ -8040,14 +8046,14 @@
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
       "license": "BSD-2-Clause",
       "optional": true
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
       "license": "MIT",
       "optional": true,
@@ -8058,7 +8064,7 @@
     },
     "node_modules/which": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/which/-/which-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
       "integrity": "sha1-2T8tk/eYNNQ2PH0MI+ANB8RmyNY=",
       "dev": true,
       "license": "ISC",
@@ -8074,7 +8080,7 @@
     },
     "node_modules/wide-align": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wide-align/-/wide-align-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
       "integrity": "sha1-3x1MIGhUNp7PPJpImPGyP72dFdM=",
       "license": "ISC",
       "optional": true,
@@ -8084,7 +8090,7 @@
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
       "dev": true,
       "license": "MIT",
@@ -8103,7 +8109,7 @@
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
       "license": "MIT",
       "dependencies": {
@@ -8120,14 +8126,14 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "devOptional": true,
       "license": "ISC"
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
       "integrity": "sha1-nc3OSe6mbY0QtCyulKecPI0MLsU=",
       "dev": true,
       "license": "MIT",
@@ -8137,7 +8143,7 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/y18n/-/y18n-5.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
       "dev": true,
       "license": "ISC",
@@ -8147,14 +8153,14 @@
     },
     "node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yallist/-/yallist-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
       "devOptional": true,
       "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yargs/-/yargs-17.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
       "integrity": "sha1-d53/5ryv7FlqcXLpgyiaWIZH+qo=",
       "dev": true,
       "license": "MIT",
@@ -8173,7 +8179,7 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha1-kJa87r+ZDSG7MfqVFuDt4pSnfTU=",
       "dev": true,
       "license": "ISC",
@@ -8183,7 +8189,7 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha1-ApTrPe4FAo0x7hpfosVWpqrxChs=",
       "dev": true,
       "license": "MIT",
@@ -8196,7 +8202,7 @@
     },
     "node_modules/zip-stream": {
       "version": "6.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/zip-stream/-/zip-stream-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
       "integrity": "sha1-4UG5MO1gzK9df6nIJg4NF0iiu/s=",
       "license": "MIT",
       "dependencies": {
@@ -8210,7 +8216,7 @@
     },
     "node_modules/zip-stream/node_modules/readable-stream": {
       "version": "4.7.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/readable-stream/-/readable-stream-4.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha1-ztvYoRRsE9//jasUBoAo1YwVrJE=",
       "license": "MIT",
       "dependencies": {
@@ -8226,7 +8232,7 @@
     },
     "node_modules/zod": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/zod/-/zod-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha1-toDxcohdGLvr8hqDTqJeVaG781Y=",
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -8,25 +8,32 @@
   "private": true,
   "type": "module",
   "main": "dist-electron/main.js",
+  "engines": {
+    "node": ">=24.19.0 <25",
+    "npm": ">=11.17.0"
+  },
   "scripts": {
-    "dev": "vite",
+    "dev": "node scripts/run-reviewed-electron.mjs dev",
     "build:vite": "vite build && node scripts/assert-catalogue-bundle-boundary.mjs",
     "build": "tsc --noEmit && npm run build:vite",
+    "check:lockfile": "node scripts/check-lockfile-portability.mjs",
     "typecheck": "tsc --noEmit",
     "typecheck:evals": "tsc --noEmit -p evals/tsconfig.json",
     "test": "node --experimental-transform-types --no-warnings --import ./evals/register.mjs --test evals/builder-imports.test.ts common/architecture-registry.test.ts electron/architectures/catalogue-registry.test.ts common/audio.test.ts common/microphone.test.ts common/narration.test.ts electron/recording-controls-bounds.test.ts electron/recording-privacy.test.ts electron/crash-guards.test.ts electron/recorder/controller.test.ts electron/recorder/session-store.test.ts electron/frames/extractor.test.ts electron/narration/audio-analysis.test.ts electron/narration/analyze-gate.test.ts electron/narration/transcribe.test.ts electron/narration/whisper.test.ts electron/sessions.test.ts electron/debug-bundle.test.ts scripts/compliance.test.mjs",
     "eval": "node --experimental-transform-types --no-warnings --import ./evals/register.mjs evals/run.ts",
     "eval:builder": "node --experimental-transform-types --no-warnings --import ./evals/register.mjs evals/builder/run.ts",
     "eval:skill": "node --experimental-transform-types --no-warnings --import ./evals/register.mjs evals/skillbuilder/run.ts",
+    "electron:install-reviewed": "node scripts/install-reviewed-electron.mjs",
     "compliance:licenses": "node scripts/prepare-compliance.mjs --licenses-only",
     "compliance:prepare": "node scripts/prepare-compliance.mjs",
     "compliance:test": "node --test scripts/compliance.test.mjs",
+    "fix:lockfile-registry": "node scripts/check-lockfile-portability.mjs --fix",
     "dist": "npm run compliance:prepare && node scripts/assert-generic-dist-platform.mjs && npm run build:vite && electron-builder --publish never",
     "dist:win:x64": "npm run compliance:prepare && node scripts/assert-native-windows-arch.mjs x64 && npm run build:vite && electron-builder --config.npmRebuild=false --publish never --win nsis --x64",
     "dist:win:arm64": "npm run compliance:prepare && node scripts/assert-native-windows-arch.mjs arm64 && npm run build:vite && electron-builder --config.npmRebuild=false --publish never --win nsis --arm64",
     "dist:portable:mac": "npm run compliance:prepare && npm run build:vite && electron-builder --publish never --mac zip",
     "dist:portable:win": "npm run compliance:prepare && node scripts/assert-native-windows-arch.mjs x64 && npm run build:vite && electron-builder --config.npmRebuild=false --publish never --win portable --x64",
-    "start": "electron ."
+    "start": "node scripts/run-reviewed-electron.mjs start"
   },
   "dependencies": {
     "@github/copilot-sdk": "^1.0.6",
@@ -42,7 +49,9 @@
     "get-windows": "^9.3.0"
   },
   "devDependencies": {
+    "@electron-internal/extract-zip": "1.0.4",
     "@electron/asar": "^3.4.1",
+    "@electron/get": "5.0.0",
     "@types/archiver": "^6.0.4",
     "@types/node": "^22.10.0",
     "@types/react": "^19.2.14",
@@ -54,6 +63,14 @@
     "typescript": "^7.0.0",
     "vite": "^8.0.16",
     "vite-plugin-electron": "1.0.4"
+  },
+  "allowScripts": {
+    "electron-winstaller": false,
+    "get-windows@9.3.0": true,
+    "koffi@3.1.1": true,
+    "onnxruntime-node@1.24.3": true,
+    "protobufjs": false,
+    "sharp@0.34.5": true
   },
   "build": {
     "appId": "com.skillrecorder.app",

--- a/scripts/check-lockfile-portability.mjs
+++ b/scripts/check-lockfile-portability.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const canonicalRegistry = "https://registry.npmjs.org/";
+const canonicalOrigin = new URL(canonicalRegistry).origin;
+const azureArtifactsHost = /(?:^|\.)pkgs\.(?:visualstudio\.com|dev\.azure\.com)$/i;
+const microsoftProxyHost = /^packagefeedproxy\.microsoft\.io$/i;
+const minimumPolicyNpm = [11, 17, 0];
+
+export function assertPolicyCapableNpm(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(String(version ?? ""));
+  if (!match) {
+    throw new Error(`Could not parse npm version: ${version}`);
+  }
+  const actual = match.slice(1).map(Number);
+  for (let index = 0; index < minimumPolicyNpm.length; index += 1) {
+    if (actual[index] > minimumPolicyNpm[index]) return;
+    if (actual[index] < minimumPolicyNpm[index]) {
+      throw new Error(
+        `npm ${minimumPolicyNpm.join(".")} or newer is required to enforce allowScripts.`,
+      );
+    }
+  }
+}
+
+function packageNameFromResolved(resolved) {
+  if (typeof resolved !== "string") return null;
+  try {
+    const url = new URL(resolved);
+    if (url.origin !== canonicalOrigin) return null;
+    const match = decodeURIComponent(url.pathname).match(
+      /^\/((?:@[^/]+\/)?[^/]+)\/-\//,
+    );
+    return match?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function registryPackagePath(url) {
+  if (azureArtifactsHost.test(url.hostname)) {
+    const marker = "/npm/registry/";
+    const index = url.pathname.lastIndexOf(marker);
+    return index === -1 ? null : url.pathname.slice(index + marker.length);
+  }
+  if (microsoftProxyHost.test(url.hostname)) {
+    return url.pathname.replace(/^\/npm\//, "");
+  }
+  return null;
+}
+
+export function normalizeLockfileRegistryUrls(lock) {
+  const packages = lock?.packages;
+  if (!packages || typeof packages !== "object") {
+    throw new Error("package-lock.json must declare a packages map.");
+  }
+
+  let changed = 0;
+  for (const entry of Object.values(packages)) {
+    if (typeof entry?.resolved !== "string") continue;
+
+    let url;
+    try {
+      url = new URL(entry.resolved);
+    } catch {
+      continue;
+    }
+    const packagePath = registryPackagePath(url);
+    if (!packagePath) continue;
+
+    entry.resolved = `${canonicalRegistry}${packagePath}${url.search}${url.hash}`;
+    changed += 1;
+  }
+  return changed;
+}
+
+export function assertPortableLockfileRegistries(lock) {
+  const packages = lock?.packages;
+  if (!packages || typeof packages !== "object") {
+    throw new Error("package-lock.json must declare a packages map.");
+  }
+
+  const invalid = [];
+  for (const [location, entry] of Object.entries(packages)) {
+    if (typeof entry?.resolved !== "string") continue;
+
+    try {
+      const url = new URL(entry.resolved);
+      if (url.origin !== canonicalOrigin) {
+        invalid.push(`${location}: ${entry.resolved}`);
+      }
+    } catch {
+      invalid.push(`${location}: ${entry.resolved}`);
+    }
+  }
+
+  if (invalid.length > 0) {
+    throw new Error(
+      "package-lock.json contains non-portable resolved URLs. Registry packages must use " +
+        `${canonicalRegistry}. Run \`npm run fix:lockfile-registry\` and review the diff:\n` +
+        invalid.slice(0, 10).join("\n"),
+    );
+  }
+}
+
+export function assertReviewedInstallScripts(lock, manifest) {
+  const packages = lock?.packages;
+  if (!packages || typeof packages !== "object") {
+    throw new Error("package-lock.json must declare a packages map.");
+  }
+  const rules = manifest?.allowScripts;
+  if (!rules || typeof rules !== "object" || Array.isArray(rules)) {
+    throw new Error("package.json must declare an allowScripts policy.");
+  }
+
+  const installScripts = [];
+  for (const [location, entry] of Object.entries(packages)) {
+    if (entry?.hasInstallScript !== true) continue;
+    const name = packageNameFromResolved(entry.resolved);
+    if (!name || typeof entry.version !== "string") {
+      throw new Error(
+        `Cannot determine the registry identity for install-script package ${location}.`,
+      );
+    }
+    installScripts.push({ location, name, version: entry.version });
+  }
+
+  const names = new Set(installScripts.map(({ name }) => name));
+  const exact = new Set(installScripts.map(({ name, version }) => `${name}@${version}`));
+  const invalidRules = [];
+  for (const [rule, decision] of Object.entries(rules)) {
+    if (typeof decision !== "boolean") {
+      invalidRules.push(`${rule} must be true or false`);
+    } else if (decision === true && !exact.has(rule)) {
+      invalidRules.push(`${rule} must pin an installed package version`);
+    } else if (decision === false && !names.has(rule) && !exact.has(rule)) {
+      invalidRules.push(`${rule} does not match an install-script package`);
+    }
+  }
+
+  const uncovered = installScripts.filter(({ name, version }) => {
+    const exactDecision = rules[`${name}@${version}`];
+    return exactDecision !== true && exactDecision !== false && rules[name] !== false;
+  });
+  if (invalidRules.length > 0 || uncovered.length > 0) {
+    const details = [
+      ...invalidRules,
+      ...uncovered.map(({ name, version }) => `${name}@${version} has no reviewed decision`),
+    ];
+    throw new Error(`Dependency install-script policy is incomplete:\n${details.join("\n")}`);
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  let fix = false;
+  let npmVersion = null;
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === "--fix" && !fix) {
+      fix = true;
+    } else if (args[index] === "--npm-version" && args[index + 1] && npmVersion === null) {
+      npmVersion = args[index + 1];
+      index += 1;
+    } else {
+      throw new Error(
+        "Usage: node scripts/check-lockfile-portability.mjs " +
+          "[--fix] [--npm-version <version>]",
+      );
+    }
+  }
+
+  const root = process.cwd();
+  const lockPath = path.join(root, "package-lock.json");
+  const manifestPath = path.join(root, "package.json");
+  const [lock, manifest] = await Promise.all([
+    readFile(lockPath, "utf8").then(JSON.parse),
+    readFile(manifestPath, "utf8").then(JSON.parse),
+  ]);
+
+  if (!npmVersion) {
+    const npmExecPath = process.env.npm_execpath;
+    if (npmExecPath) {
+      try {
+        const npmManifest = JSON.parse(
+          await readFile(path.resolve(path.dirname(npmExecPath), "..", "package.json"), "utf8"),
+        );
+        npmVersion = npmManifest.version ?? null;
+      } catch {
+        // Fall back to npm's user-agent value below.
+      }
+    }
+    npmVersion ??=
+      /\bnpm\/([^\s]+)/.exec(process.env.npm_config_user_agent ?? "")?.[1] ?? null;
+  }
+  if (npmVersion) {
+    assertPolicyCapableNpm(npmVersion);
+  }
+
+  if (fix) {
+    const changed = normalizeLockfileRegistryUrls(lock);
+    if (changed > 0) {
+      await writeFile(lockPath, `${JSON.stringify(lock, null, 2)}\n`);
+    }
+    console.log(`Normalized ${changed} lockfile registry URL${changed === 1 ? "" : "s"}.`);
+  }
+
+  assertPortableLockfileRegistries(lock);
+  assertReviewedInstallScripts(lock, manifest);
+  console.log("Lockfile registry URLs and dependency install scripts are portable and reviewed.");
+}
+
+const isMain =
+  process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  await main();
+}

--- a/scripts/compliance.test.mjs
+++ b/scripts/compliance.test.mjs
@@ -7,6 +7,17 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
+  assertPortableLockfileRegistries,
+  assertPolicyCapableNpm,
+  assertReviewedInstallScripts,
+  normalizeLockfileRegistryUrls,
+} from "./check-lockfile-portability.mjs";
+import {
+  assertReviewedPackagePath,
+  exitCodeForSignal,
+  sanitizeElectronEnvironment,
+} from "./run-reviewed-electron.mjs";
+import {
   assertReviewedCopilotCliVersions,
   buildNativeSourceSpecs,
   deterministicGitConfigArgs,
@@ -53,6 +64,9 @@ const nativeVersions = {
 };
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repoManifest = JSON.parse(
+  await readFile(path.join(repoRoot, "package.json"), "utf8"),
+);
 
 test("license filenames include common suffixed forms", () => {
   assert.equal(isLicenseFileName("LICENSE"), true);
@@ -199,6 +213,99 @@ test("platform Sharp/libvips packages use the reviewed LGPL text", () => {
   );
 });
 
+test("the lockfile is registry-portable and install scripts are reviewed", async () => {
+  const lock = JSON.parse(
+    await readFile(path.join(repoRoot, "package-lock.json"), "utf8"),
+  );
+  assert.doesNotThrow(() => assertPortableLockfileRegistries(lock));
+  assert.doesNotThrow(() => assertReviewedInstallScripts(lock, repoManifest));
+
+  const internal = {
+    packages: {
+      "node_modules/example": {
+        version: "1.0.0",
+        resolved:
+          "https://ms-feed-25.pkgs.visualstudio.com/feed/_packaging/npm/npm/registry/example/-/example-1.0.0.tgz",
+      },
+    },
+  };
+  assert.throws(
+    () => assertPortableLockfileRegistries(internal),
+    /non-portable resolved URLs/,
+  );
+  assert.equal(normalizeLockfileRegistryUrls(internal), 1);
+  assert.equal(
+    internal.packages["node_modules/example"].resolved,
+    "https://registry.npmjs.org/example/-/example-1.0.0.tgz",
+  );
+  assert.doesNotThrow(() => assertPortableLockfileRegistries(internal));
+
+  const scriptLock = {
+    packages: {
+      "node_modules/native-alias": {
+        version: "2.0.0",
+        resolved: "https://registry.npmjs.org/native/-/native-2.0.0.tgz",
+        hasInstallScript: true,
+      },
+      "node_modules/noisy": {
+        version: "3.0.0",
+        resolved: "https://registry.npmjs.org/noisy/-/noisy-3.0.0.tgz",
+        hasInstallScript: true,
+      },
+    },
+  };
+  assert.doesNotThrow(() =>
+    assertReviewedInstallScripts(scriptLock, {
+      allowScripts: { "native@2.0.0": true, noisy: false },
+    }),
+  );
+  assert.throws(
+    () =>
+      assertReviewedInstallScripts(scriptLock, {
+        allowScripts: { "native-alias": false },
+      }),
+    /does not match an install-script package/,
+  );
+  assert.throws(
+    () =>
+      assertReviewedInstallScripts(scriptLock, {
+        allowScripts: { native: true },
+      }),
+    /must pin an installed package version/,
+  );
+  assert.throws(
+    () => assertReviewedInstallScripts(scriptLock, { allowScripts: {} }),
+    /has no reviewed decision/,
+  );
+  assert.doesNotThrow(() => assertPolicyCapableNpm("11.17.0"));
+  assert.doesNotThrow(() => assertPolicyCapableNpm("12.0.0"));
+  assert.throws(
+    () => assertPolicyCapableNpm("11.16.0"),
+    /npm 11\.17\.0 or newer/,
+  );
+
+  assert.deepEqual(
+    sanitizeElectronEnvironment({
+      ELECTRON_OVERRIDE_DIST_PATH: "unreviewed",
+      npm_config_electron_customdir: "wrong-release",
+      npm_config_electron_mirror: "https://example.invalid",
+      npm_package_config_electron_customFilename: "wrong.zip",
+      npm_package_config_electron_use_remote_checksums: "1",
+      PATH: "retained",
+    }),
+    { PATH: "retained" },
+  );
+  assert.doesNotThrow(() =>
+    assertReviewedPackagePath("electron.exe", "electron.exe"),
+  );
+  assert.throws(
+    () => assertReviewedPackagePath("electron.exe", "unreviewed.exe"),
+    /does not match the reviewed runtime/,
+  );
+  assert.equal(exitCodeForSignal("SIGINT"), 130);
+  assert.equal(exitCodeForSignal("SIGTERM"), 143);
+});
+
 test("unreviewed source hashes fail closed", () => {
   assert.equal(
     reviewedMaterialHash("source", { source: "a".repeat(64) }, "Source material"),
@@ -308,6 +415,7 @@ test("source and release instructions remain compliance-preserving", async () =>
     readme,
     releasing,
     windowsWorkflow,
+    electronInstaller,
   ] = await Promise.all([
     readFile(path.join(repoRoot, "install.ps1"), "utf8"),
     readFile(path.join(repoRoot, "install.sh"), "utf8"),
@@ -318,6 +426,10 @@ test("source and release instructions remain compliance-preserving", async () =>
       path.join(repoRoot, ".github", "workflows", "windows.yml"),
       "utf8",
     ),
+    readFile(
+      path.join(repoRoot, "scripts", "install-reviewed-electron.mjs"),
+      "utf8",
+    ),
   ]);
 
   assert.match(windowsInstaller, /\^\[0-9a-fA-F\]\{40\}\$/);
@@ -326,10 +438,13 @@ test("source and release instructions remain compliance-preserving", async () =>
     /https:\/\/codeload\.github\.com\/microsoft\/skill-recorder\/zip\/\$Commit/,
   );
   assert.match(windowsInstaller, /https:\/\/nodejs\.org\/dist\/index\.json/);
-  assert.match(windowsInstaller, /NPM_CONFIG_REGISTRY = "https:\/\/registry\.npmjs\.org\/"/);
+  assert.doesNotMatch(
+    windowsInstaller,
+    /NPM_CONFIG_(?:REGISTRY|REPLACE_REGISTRY_HOST)/,
+  );
   assert.match(
     windowsInstaller,
-    /ELECTRON_MIRROR = "https:\/\/github\.com\/electron\/electron\/releases\/download\/"/,
+    /https:\/\/github\.com\/electron\/electron\/releases\/download\//,
   );
   assert.match(windowsInstaller, /SHASUMS256\.txt/);
   assert.match(windowsInstaller, /Get-AuthenticodeSignature/);
@@ -358,8 +473,21 @@ test("source and release instructions remain compliance-preserving", async () =>
     windowsInstaller,
     /\(& \$nodeExe [^\r\n]+\| Select-Object -First 1\)/,
   );
-  assert.match(windowsInstaller, /@?\("ci", "--no-audit", "--no-fund"\)/);
-  assert.match(windowsInstaller, /@?\("node_modules\\electron\\install\.js"\)/);
+  assert.match(
+    windowsInstaller,
+    /"ci",\s+"--no-audit",\s+"--no-fund",\s+"--ignore-scripts=false",\s+"--dangerously-allow-all-scripts=false",\s+"--strict-allow-scripts"/,
+  );
+  assert.match(windowsInstaller, /"scripts\\check-lockfile-portability\.mjs"/);
+  assert.match(windowsInstaller, /"scripts\\install-reviewed-electron\.mjs"/);
+  assert.doesNotMatch(windowsInstaller, /node_modules\\electron\\install\.js/);
+  assert.match(
+    windowsInstaller,
+    /Move-DirectoryTree -Source \$buildDirectory -Destination \$sourceDirectory/,
+  );
+  assert.match(
+    windowsInstaller,
+    /Move-DirectoryTree -Source \$expandedDirectory -Destination \$runtimeDirectory/,
+  );
   assert.match(windowsInstaller, /@?\("run", "compliance:licenses"\)/);
   assert.match(windowsInstaller, /@?\("run", "build"\)/);
   assert.doesNotMatch(
@@ -385,14 +513,28 @@ test("source and release instructions remain compliance-preserving", async () =>
     /https:\/\/codeload\.github\.com\/microsoft\/skill-recorder\/tar\.gz\/\$COMMIT/,
   );
   assert.match(unixInstaller, /https:\/\/nodejs\.org\/dist\/latest-v24\.x/);
-  assert.match(unixInstaller, /NPM_CONFIG_REGISTRY="https:\/\/registry\.npmjs\.org\/"/);
+  assert.doesNotMatch(
+    unixInstaller,
+    /NPM_CONFIG_(?:REGISTRY|REPLACE_REGISTRY_HOST)/,
+  );
   assert.match(
     unixInstaller,
-    /ELECTRON_MIRROR="https:\/\/github\.com\/electron\/electron\/releases\/download\/"/,
+    /https:\/\/github\.com\/electron\/electron\/releases\/download\//,
   );
   assert.match(unixInstaller, /SHASUMS256\.txt/);
-  assert.match(unixInstaller, /"\$NPM" ci --no-audit --no-fund/);
-  assert.match(unixInstaller, /"\$NODE" "node_modules\/electron\/install\.js"/);
+  assert.match(
+    unixInstaller,
+    /"\$NPM" ci \\\s+--no-audit \\\s+--no-fund \\\s+--ignore-scripts=false \\\s+--dangerously-allow-all-scripts=false \\\s+--strict-allow-scripts/,
+  );
+  assert.match(
+    unixInstaller,
+    /"\$NODE" "scripts\/check-lockfile-portability\.mjs"/,
+  );
+  assert.match(
+    unixInstaller,
+    /"\$NODE" "scripts\/install-reviewed-electron\.mjs"/,
+  );
+  assert.doesNotMatch(unixInstaller, /node_modules\/electron\/install\.js/);
   assert.match(unixInstaller, /"\$NPM" run compliance:licenses/);
   assert.match(unixInstaller, /"\$NPM" run build/);
   assert.match(unixInstaller, /\.compliance\/licenses\/LGPL-3\.0\.txt/);
@@ -406,10 +548,28 @@ test("source and release instructions remain compliance-preserving", async () =>
   assert.match(instructions, /generated build is for local execution only/i);
   assert.match(instructions, /npm ci/);
   assert.match(instructions, /full 40-character commit SHA/i);
+  assert.match(instructions, /npm 11\.17/i);
   assert.match(instructions, /macOS/);
   assert.match(instructions, /Ubuntu/);
   assert.match(instructions, /complete generated\s+compliance bundle/i);
   assert.doesNotMatch(instructions, /raw\.githubusercontent\.com\/[^ \n]+\/(?:master|main)\//i);
+  assert.match(electronInstaller, /createHash\("sha256"\)/);
+  assert.match(electronInstaller, /@electron-internal\/extract-zip/);
+  assert.match(electronInstaller, /@electron\/get/);
+  assert.match(electronInstaller, /checksums,/);
+  assert.match(electronInstaller, /initializeProxy\(\)/);
+  assert.match(
+    electronInstaller,
+    /https:\/\/github\.com\/electron\/electron\/releases\/download\//,
+  );
+  assert.equal(
+    repoManifest.scripts.dev,
+    "node scripts/run-reviewed-electron.mjs dev",
+  );
+  assert.equal(
+    repoManifest.scripts.start,
+    "node scripts/run-reviewed-electron.mjs start",
+  );
   assert.match(instructions, /SKILL_RECORDER_NO_DESKTOP_SHORTCUT=1/);
   assert.match(instructions, /GetFolderPath\('DesktopDirectory'\)/);
   assert.match(readme, /\[`INSTALL\.md`\]\(INSTALL\.md\)/);

--- a/scripts/install-reviewed-electron.mjs
+++ b/scripts/install-reviewed-electron.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { createReadStream, existsSync } from "node:fs";
+import {
+  access,
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+import { sanitizeElectronEnvironment } from "./run-reviewed-electron.mjs";
+
+const require = createRequire(import.meta.url);
+const { extract } = require("@electron-internal/extract-zip");
+const officialElectronReleases =
+  "https://github.com/electron/electron/releases/download/";
+const reviewedMetadataName = ".skill-recorder-reviewed.json";
+
+function parseArguments(args) {
+  const options = {
+    archive: null,
+    platform: process.platform,
+    arch: process.arch,
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (!["--archive", "--platform", "--arch"].includes(argument) || !args[index + 1]) {
+      throw new Error(
+        "Usage: node scripts/install-reviewed-electron.mjs " +
+          "[--archive <zip>] [--platform <platform>] [--arch <architecture>]",
+      );
+    }
+    options[argument.slice(2)] = args[index + 1];
+    index += 1;
+  }
+  return options;
+}
+
+function platformExecutable(platform) {
+  switch (platform) {
+    case "darwin":
+      return "Electron.app/Contents/MacOS/Electron";
+    case "linux":
+      return "electron";
+    case "win32":
+      return "electron.exe";
+    default:
+      throw new Error(`Electron is not reviewed for platform ${platform}.`);
+  }
+}
+
+async function sha256File(file) {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(file)) {
+    hash.update(chunk);
+  }
+  return hash.digest("hex");
+}
+
+async function withSanitizedElectronEnvironment(callback) {
+  const sanitized = sanitizeElectronEnvironment(process.env);
+  const removed = [];
+  for (const key of Object.keys(process.env)) {
+    if (!(key in sanitized)) {
+      removed.push([key, process.env[key]]);
+      delete process.env[key];
+    }
+  }
+  try {
+    return await callback();
+  } finally {
+    for (const [key, value] of removed) {
+      process.env[key] = value;
+    }
+  }
+}
+
+async function installArchive(archive, electronDirectory, platformPath, version) {
+  const distDirectory = path.join(electronDirectory, "dist");
+  await rm(path.join(electronDirectory, reviewedMetadataName), { force: true });
+  await rm(distDirectory, { recursive: true, force: true });
+  await mkdir(distDirectory, { recursive: true });
+  await extract(archive, { dir: distDirectory });
+
+  const bundledTypes = path.join(distDirectory, "electron.d.ts");
+  if (existsSync(bundledTypes)) {
+    const packageTypes = path.join(electronDirectory, "electron.d.ts");
+    await rm(packageTypes, { force: true });
+    await rename(bundledTypes, packageTypes);
+  }
+  await writeFile(path.join(electronDirectory, "path.txt"), platformPath);
+
+  const installedVersion = (
+    await readFile(path.join(distDirectory, "version"), "utf8")
+  ).trim().replace(/^v/, "");
+  if (installedVersion !== version) {
+    throw new Error(
+      `Electron runtime version mismatch. Expected ${version}, got ${installedVersion}.`,
+    );
+  }
+  const executable = path.join(distDirectory, platformPath);
+  await access(executable);
+  return sha256File(executable);
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2));
+  const root = process.cwd();
+  const electronDirectory = path.join(root, "node_modules", "electron");
+  const [electronPackage, checksums, policy] = await Promise.all([
+    readFile(path.join(electronDirectory, "package.json"), "utf8").then(JSON.parse),
+    readFile(path.join(electronDirectory, "checksums.json"), "utf8").then(JSON.parse),
+    readFile(path.join(root, "third_party", "compliance-policy.json"), "utf8").then(JSON.parse),
+  ]);
+
+  if (electronPackage.version !== policy.electron?.version) {
+    throw new Error("Installed Electron version has not been reviewed by the compliance policy.");
+  }
+  const distributionKey = `${options.platform}-${options.arch}`;
+  const archiveName =
+    `electron-v${electronPackage.version}-${options.platform}-${options.arch}.zip`;
+  const expectedHash = policy.electron.distributions?.[distributionKey];
+  if (!/^[0-9a-f]{64}$/i.test(expectedHash ?? "")) {
+    throw new Error(`No reviewed Electron distribution exists for ${distributionKey}.`);
+  }
+  if (String(checksums[archiveName] ?? "").toLowerCase() !== expectedHash.toLowerCase()) {
+    throw new Error("Electron's bundled checksum does not match the reviewed distribution hash.");
+  }
+
+  let archive = options.archive && path.resolve(options.archive);
+  if (!archive) {
+    archive = await withSanitizedElectronEnvironment(async () => {
+      const { downloadArtifact, initializeProxy } = require("@electron/get");
+      initializeProxy();
+      return downloadArtifact({
+        version: electronPackage.version,
+        artifactName: "electron",
+        platform: options.platform,
+        arch: options.arch,
+        checksums,
+        mirrorOptions: {
+          mirror: officialElectronReleases,
+          customDir: `v${electronPackage.version}`,
+          customFilename: archiveName,
+        },
+      });
+    });
+  }
+
+  const actualHash = await sha256File(archive);
+  if (actualHash !== expectedHash.toLowerCase()) {
+    throw new Error(
+      `Electron archive SHA-256 mismatch. Expected ${expectedHash}, got ${actualHash}.`,
+    );
+  }
+  const executableSha256 = await installArchive(
+    archive,
+    electronDirectory,
+    platformExecutable(options.platform),
+    electronPackage.version,
+  );
+  const metadataPath = path.join(electronDirectory, reviewedMetadataName);
+  const temporaryMetadataPath = `${metadataPath}.${process.pid}.tmp`;
+  await writeFile(
+    temporaryMetadataPath,
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        version: electronPackage.version,
+        platform: options.platform,
+        arch: options.arch,
+        archiveSha256: actualHash,
+        executable: platformExecutable(options.platform),
+        executableSha256,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await rename(temporaryMetadataPath, metadataPath);
+
+  console.log(`Installed reviewed Electron ${electronPackage.version} for ${distributionKey}.`);
+}
+
+await main();

--- a/scripts/install-windows.test.ps1
+++ b/scripts/install-windows.test.ps1
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Skill Recorder contributors
+
+param(
+  [string]$InstallerPath = (Join-Path (Split-Path -Parent $PSScriptRoot) "install.ps1")
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$tokens = $null
+$parseErrors = $null
+$installerAst = [System.Management.Automation.Language.Parser]::ParseFile(
+  $InstallerPath,
+  [ref]$tokens,
+  [ref]$parseErrors
+)
+if ($parseErrors.Count -ne 0) {
+  $parseErrors | ForEach-Object { Write-Error $_.Message }
+  throw "install.ps1 contains PowerShell syntax errors"
+}
+
+$helperNames = @(
+  "ConvertTo-ExtendedLengthPath",
+  "Move-DirectoryTree",
+  "Remove-DirectoryTree"
+)
+$functionDefinitions = @(
+  $installerAst.FindAll(
+    {
+      param($node)
+      $node -is [System.Management.Automation.Language.FunctionDefinitionAst]
+    },
+    $true
+  )
+)
+$helperSource = @(
+  foreach ($helperName in $helperNames) {
+    $matches = @($functionDefinitions | Where-Object Name -eq $helperName)
+    if ($matches.Count -ne 1) {
+      throw "Expected one $helperName definition in install.ps1, found $($matches.Count)."
+    }
+    $matches[0].Extent.Text
+  }
+)
+. ([scriptblock]::Create($helperSource -join [Environment]::NewLine))
+
+$uncPath = ConvertTo-ExtendedLengthPath -Path "\\server\share\folder"
+if ($uncPath -ne "\\?\UNC\server\share\folder") {
+  throw "Extended-length UNC conversion returned an unexpected path: $uncPath"
+}
+
+$testRoot = Join-Path (
+  [IO.Path]::GetTempPath()
+) ("skill-recorder-installer-" + [guid]::NewGuid().ToString("N"))
+$sourceDirectory = Join-Path $testRoot ("source-" + ("a" * 96))
+$nestedDirectoryName = "b" * 120
+$sourceFile = Join-Path (
+  Join-Path $sourceDirectory $nestedDirectoryName
+) "coverage.json"
+$destinationDirectory = Join-Path $testRoot "build"
+$destinationFile = Join-Path (
+  Join-Path $destinationDirectory $nestedDirectoryName
+) "coverage.json"
+
+try {
+  [IO.Directory]::CreateDirectory(
+    (ConvertTo-ExtendedLengthPath -Path (Split-Path -Parent $sourceFile))
+  ) | Out-Null
+  [IO.File]::WriteAllText(
+    (ConvertTo-ExtendedLengthPath -Path $sourceFile),
+    "installer long-path regression"
+  )
+  [IO.File]::SetAttributes(
+    (ConvertTo-ExtendedLengthPath -Path $sourceFile),
+    [IO.FileAttributes]::ReadOnly
+  )
+
+  if ($sourceFile.Length -le 260) {
+    throw "Long-path test setup produced only $($sourceFile.Length) characters."
+  }
+
+  Move-DirectoryTree -Source $sourceDirectory -Destination $destinationDirectory
+  if ([IO.Directory]::Exists((ConvertTo-ExtendedLengthPath -Path $sourceDirectory))) {
+    throw "Move-DirectoryTree left the source directory behind."
+  }
+  if (-not [IO.File]::Exists((ConvertTo-ExtendedLengthPath -Path $destinationFile))) {
+    throw "Move-DirectoryTree did not move the long-path test file."
+  }
+
+  Remove-DirectoryTree -Path $destinationDirectory
+  if ([IO.Directory]::Exists((ConvertTo-ExtendedLengthPath -Path $destinationDirectory))) {
+    throw "Remove-DirectoryTree left the destination directory behind."
+  }
+
+  $lockedSourceDirectory = Join-Path $testRoot "locked-source"
+  $lockedDestinationDirectory = Join-Path $testRoot "locked-destination"
+  $lockedFile = Join-Path $lockedSourceDirectory "scanned.exe"
+  $readyFile = Join-Path $testRoot "locker-ready"
+  [IO.Directory]::CreateDirectory($lockedSourceDirectory) | Out-Null
+  [IO.File]::WriteAllText($lockedFile, "endpoint scanner simulation")
+
+  $escapedLockedFile = $lockedFile.Replace("'", "''")
+  $escapedReadyFile = $readyFile.Replace("'", "''")
+  $lockerSource = @"
+`$stream = [IO.File]::Open(
+  '$escapedLockedFile',
+  [IO.FileMode]::Open,
+  [IO.FileAccess]::Read,
+  [IO.FileShare]::Read
+)
+try {
+  [IO.File]::WriteAllText('$escapedReadyFile', 'ready')
+  Start-Sleep -Milliseconds 500
+} finally {
+  `$stream.Dispose()
+}
+"@
+  $encodedLockerSource = [Convert]::ToBase64String(
+    [Text.Encoding]::Unicode.GetBytes($lockerSource)
+  )
+  $powerShellExecutable = [Diagnostics.Process]::GetCurrentProcess().MainModule.FileName
+  $locker = Start-Process `
+    -FilePath $powerShellExecutable `
+    -ArgumentList @("-NoProfile", "-NonInteractive", "-EncodedCommand", $encodedLockerSource) `
+    -PassThru
+  try {
+    $readyDeadline = (Get-Date).AddSeconds(10)
+    while (-not [IO.File]::Exists($readyFile)) {
+      if ((Get-Date) -ge $readyDeadline -or $locker.HasExited) {
+        throw "The directory-lock test helper did not become ready."
+      }
+      Start-Sleep -Milliseconds 25
+    }
+
+    Move-DirectoryTree `
+      -Source $lockedSourceDirectory `
+      -Destination $lockedDestinationDirectory `
+      -MaxAttempts 6 `
+      -RetryDelayMilliseconds 100
+    if (-not [IO.Directory]::Exists($lockedDestinationDirectory)) {
+      throw "Move-DirectoryTree did not recover from a transient file lock."
+    }
+  } finally {
+    if (-not $locker.HasExited) {
+      Stop-Process -Id $locker.Id -Force
+      $locker.WaitForExit()
+    }
+    $locker.Dispose()
+  }
+} finally {
+  Remove-DirectoryTree -Path $testRoot
+}
+
+Write-Host "Windows installer filesystem tests passed."

--- a/scripts/run-reviewed-electron.mjs
+++ b/scripts/run-reviewed-electron.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { spawn } from "node:child_process";
+import { createReadStream } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { constants as osConstants } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const reviewedMetadataName = ".skill-recorder-reviewed.json";
+const dangerousElectronEnvironment = new Set([
+  "electron_config_cache",
+  "electron_custom_dir",
+  "electron_customdir",
+  "electron_custom_filename",
+  "electron_customfilename",
+  "electron_custom_version",
+  "electron_customversion",
+  "electron_mirror",
+  "electron_nightly_mirror",
+  "electron_nightlymirror",
+  "electron_override_dist_path",
+  "electron_run_as_node",
+  "electron_skip_binary_download",
+  "electron_use_remote_checksums",
+  "force_no_cache",
+]);
+
+export function sanitizeElectronEnvironment(environment) {
+  const sanitized = {};
+  for (const [key, value] of Object.entries(environment)) {
+    const normalized = key
+      .toLowerCase()
+      .replace(/^npm_(?:config|package_config)_/, "");
+    if (!dangerousElectronEnvironment.has(normalized)) {
+      sanitized[key] = value;
+    }
+  }
+  return sanitized;
+}
+
+export function assertReviewedPackagePath(reviewedPath, packagePath) {
+  if (packagePath !== reviewedPath) {
+    throw new Error(
+      "Electron's package path does not match the reviewed runtime. " +
+        "Run `npm run electron:install-reviewed`.",
+    );
+  }
+}
+
+export function exitCodeForSignal(signal) {
+  return 128 + (osConstants.signals[signal] ?? 1);
+}
+
+async function sha256File(file) {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(file)) {
+    hash.update(chunk);
+  }
+  return hash.digest("hex");
+}
+
+export async function verifyReviewedRuntime(root) {
+  const electronDirectory = path.join(root, "node_modules", "electron");
+  const [metadata, electronPackage, checksums, policy, packagePath] = await Promise.all([
+    readFile(path.join(electronDirectory, reviewedMetadataName), "utf8").then(JSON.parse),
+    readFile(path.join(electronDirectory, "package.json"), "utf8").then(JSON.parse),
+    readFile(path.join(electronDirectory, "checksums.json"), "utf8").then(JSON.parse),
+    readFile(path.join(root, "third_party", "compliance-policy.json"), "utf8").then(JSON.parse),
+    readFile(path.join(electronDirectory, "path.txt"), "utf8"),
+  ]);
+
+  const distributionKey = `${metadata.platform}-${metadata.arch}`;
+  const archiveName =
+    `electron-v${metadata.version}-${metadata.platform}-${metadata.arch}.zip`;
+  const reviewedArchiveHash = policy.electron?.distributions?.[distributionKey];
+  if (
+    metadata.schemaVersion !== 1 ||
+    metadata.version !== electronPackage.version ||
+    metadata.version !== policy.electron?.version ||
+    metadata.archiveSha256 !== reviewedArchiveHash ||
+    checksums[archiveName] !== reviewedArchiveHash
+  ) {
+    throw new Error(
+      "Electron review metadata is invalid. Run `npm run electron:install-reviewed`.",
+    );
+  }
+
+  const executable = path.resolve(electronDirectory, "dist", metadata.executable);
+  const distDirectory = `${path.resolve(electronDirectory, "dist")}${path.sep}`;
+  if (!executable.startsWith(distDirectory)) {
+    throw new Error("Reviewed Electron executable escapes its distribution directory.");
+  }
+  assertReviewedPackagePath(metadata.executable, packagePath);
+  const executableHash = await sha256File(executable);
+  if (executableHash !== metadata.executableSha256) {
+    throw new Error(
+      "The reviewed Electron executable has changed. Run `npm run electron:install-reviewed`.",
+    );
+  }
+  return executable;
+}
+
+async function run(command, args, root) {
+  const child = spawn(command, args, {
+    cwd: root,
+    env: sanitizeElectronEnvironment(process.env),
+    stdio: "inherit",
+    windowsHide: false,
+  });
+  const signals =
+    process.platform === "win32"
+      ? ["SIGINT", "SIGTERM", "SIGBREAK"]
+      : ["SIGINT", "SIGTERM", "SIGHUP", "SIGUSR2"];
+  let forwardedSignal = null;
+  let forceKillTimer = null;
+  const handlers = new Map();
+  for (const signal of signals) {
+    const handler = () => {
+      if (forwardedSignal) {
+        child.kill("SIGKILL");
+        return;
+      }
+      forwardedSignal = signal;
+      child.kill(signal);
+      forceKillTimer = setTimeout(() => child.kill("SIGKILL"), 5000);
+      forceKillTimer.unref();
+    };
+    handlers.set(signal, handler);
+    process.on(signal, handler);
+  }
+
+  const code = await new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (exitCode, signal) => {
+      if (forwardedSignal) {
+        resolve(exitCodeForSignal(forwardedSignal));
+      } else if (signal) {
+        reject(new Error(`Reviewed Electron command exited from signal ${signal}.`));
+      } else {
+        resolve(exitCode ?? 1);
+      }
+    });
+  }).finally(() => {
+    if (forceKillTimer) clearTimeout(forceKillTimer);
+    for (const [signal, handler] of handlers) {
+      process.off(signal, handler);
+    }
+  });
+  process.exitCode = code;
+}
+
+async function main() {
+  const [mode, ...args] = process.argv.slice(2);
+  if (!["dev", "start"].includes(mode)) {
+    throw new Error("Usage: node scripts/run-reviewed-electron.mjs <dev|start> [arguments...]");
+  }
+
+  const root = process.cwd();
+  const executable = await verifyReviewedRuntime(root);
+  if (mode === "start") {
+    await run(executable, [root, ...args], root);
+  } else {
+    await run(
+      process.execPath,
+      [path.join(root, "node_modules", "vite", "bin", "vite.js"), ...args],
+      root,
+    );
+  }
+}
+
+const isMain =
+  process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  await main();
+}


### PR DESCRIPTION
## Summary
- canonicalize lockfile registry URLs while honoring each user's configured npm registry or compatible corporate mirror
- enforce reviewed dependency lifecycle scripts and install/launch only the hash-verified Electron runtime
- retry Windows directory moves that are temporarily locked by Defender or endpoint security

## Validation
- strict npm 11.17 install through public npmjs
- strict npm 11.17 install through Microsoft's package-feed proxy
- reviewed Electron 43.1.1 installation and runtime verification
- 268-package license inventory, 73 tests, and production build