### PR TITLE
feat: add generic Agent Skill export target

### DIFF
--- a/common/architecture-registry.test.ts
+++ b/common/architecture-registry.test.ts
@@ -62,7 +62,7 @@ test("the manifest derives architecture validation and target availability", () 
   assert.deepEqual(enabledArchitectureLabels("skill"), [
     "Scout",
     "Cowork",
-    "Agent Skill",
+    "Agent skill",
   ]);
   assert.deepEqual(enabledArchitectureLabels("automation"), ["Scout"]);
 });

--- a/common/architecture-registry.test.ts
+++ b/common/architecture-registry.test.ts
@@ -20,6 +20,7 @@ test("the manifest derives architecture validation and target availability", () 
   assert.deepEqual(SkillArchitecture.options, [
     "scout",
     "cowork",
+    "agent-skill",
     "copilot-studio",
   ]);
   assert.equal(SkillArchitecture.safeParse("generic").success, false);
@@ -29,6 +30,7 @@ test("the manifest derives architecture validation and target availability", () 
     [
       ["scout", true],
       ["cowork", true],
+      ["agent-skill", true],
       ["copilot-studio", false],
     ],
   );
@@ -46,6 +48,7 @@ test("the manifest derives architecture validation and target availability", () 
       ["scout", "skill", true, ["install", "export"], "Scout"],
       ["scout", "automation", true, ["install"], "Scout"],
       ["cowork", "skill", true, ["export"], "Microsoft 365 Copilot"],
+      ["agent-skill", "skill", true, ["export"], "your agent"],
       ["copilot-studio", "skill", false, ["export"], "Copilot Studio"],
     ],
   );
@@ -56,7 +59,11 @@ test("the manifest derives architecture validation and target availability", () 
     "Scout",
   );
 
-  assert.deepEqual(enabledArchitectureLabels("skill"), ["Scout", "Cowork"]);
+  assert.deepEqual(enabledArchitectureLabels("skill"), [
+    "Scout",
+    "Cowork",
+    "Agent Skill",
+  ]);
   assert.deepEqual(enabledArchitectureLabels("automation"), ["Scout"]);
 });
 

--- a/common/architecture-registry.ts
+++ b/common/architecture-registry.ts
@@ -124,15 +124,14 @@ export const ARCHITECTURE_MANIFEST = defineArchitectures([
     // Export-only, so this label is never surfaced; kept non-blank for the manifest
     // invariant and as a sensible fallback if the target ever gains an install path.
     installTargetLabel: "your agent",
-    note: "Any AI agent that supports skills — portable, with no host-specific tools.",
+    note: "Any skill-capable agent. Not tuned to specific tools — you verify it can perform the tasks.",
     targets: [
       {
         kind: "skill",
         label: "Agent skill",
         enabled: true,
         note:
-          "A portable skill you export and load into any agent that supports skills. " +
-          "Assumes no host-specific tools.",
+          "Any skill-capable agent. Not tuned to specific tools — you verify it can perform the tasks.",
         placements: ["export"],
       },
     ],

--- a/common/architecture-registry.ts
+++ b/common/architecture-registry.ts
@@ -124,14 +124,14 @@ export const ARCHITECTURE_MANIFEST = defineArchitectures([
     // Export-only, so this label is never surfaced; kept non-blank for the manifest
     // invariant and as a sensible fallback if the target ever gains an install path.
     installTargetLabel: "your agent",
-    note: "Any skill-capable agent. Not tuned to specific tools — you verify it can perform the tasks.",
+    note: "Any skill-capable agent. Not tuned to specific tools. You verify it can perform the tasks.",
     targets: [
       {
         kind: "skill",
         label: "Agent skill",
         enabled: true,
         note:
-          "Any skill-capable agent. Not tuned to specific tools — you verify it can perform the tasks.",
+          "Any skill-capable agent. Not tuned to specific tools. You verify it can perform the tasks.",
         placements: ["export"],
       },
     ],

--- a/common/architecture-registry.ts
+++ b/common/architecture-registry.ts
@@ -120,15 +120,15 @@ export const ARCHITECTURE_MANIFEST = defineArchitectures([
   },
   {
     id: "agent-skill",
-    label: "Agent Skill",
+    label: "Agent skill",
     // Export-only, so this label is never surfaced; kept non-blank for the manifest
     // invariant and as a sensible fallback if the target ever gains an install path.
     installTargetLabel: "your agent",
-    note: "Any AI Agent with Skill support",
+    note: "Any AI agent that supports skills — portable, with no host-specific tools.",
     targets: [
       {
         kind: "skill",
-        label: "Agent Skill",
+        label: "Agent skill",
         enabled: true,
         note:
           "A portable skill you export and load into any agent that supports skills. " +

--- a/common/architecture-registry.ts
+++ b/common/architecture-registry.ts
@@ -119,6 +119,25 @@ export const ARCHITECTURE_MANIFEST = defineArchitectures([
     ],
   },
   {
+    id: "agent-skill",
+    label: "Agent Skill",
+    // Export-only, so this label is never surfaced; kept non-blank for the manifest
+    // invariant and as a sensible fallback if the target ever gains an install path.
+    installTargetLabel: "your agent",
+    note: "Any AI Agent with Skill support",
+    targets: [
+      {
+        kind: "skill",
+        label: "Agent Skill",
+        enabled: true,
+        note:
+          "A portable skill you export and load into any agent that supports skills. " +
+          "Assumes no host-specific tools.",
+        placements: ["export"],
+      },
+    ],
+  },
+  {
     id: "copilot-studio",
     label: "Copilot Studio",
     installTargetLabel: "Copilot Studio",

--- a/electron/architectures/catalogue-registry.test.ts
+++ b/electron/architectures/catalogue-registry.test.ts
@@ -11,6 +11,7 @@ import {
   defineCatalogueProvider,
   providersFromModules,
 } from "./catalogue-provider";
+import agentSkillCatalogueProvider from "./catalogues/agent-skill-catalogue";
 import coworkCatalogueProvider from "./catalogues/cowork-catalogue";
 import scoutCatalogueProvider from "./catalogues/scout-catalogue";
 
@@ -26,6 +27,11 @@ const scoutProvider = defineCatalogueProvider({
 const coworkProvider = defineCatalogueProvider({
   architecture: "cowork",
   skill: { version: "cowork-skill-v1", content: "Cowork skill catalogue" },
+});
+
+const agentSkillProvider = defineCatalogueProvider({
+  architecture: "agent-skill",
+  skill: { version: "agent-skill-v1", content: "Agent Skill catalogue" },
 });
 
 function sha256(content: string): string {
@@ -44,7 +50,11 @@ function providersWithScoutSkill(skill: unknown): readonly unknown[] {
 }
 
 test("the registry resolves enabled catalogues and derives unavailable errors", () => {
-  const registry = createCatalogueRegistry([scoutProvider, coworkProvider]);
+  const registry = createCatalogueRegistry([
+    scoutProvider,
+    coworkProvider,
+    agentSkillProvider,
+  ]);
 
   assert.deepEqual(registry.catalogueFor("scout", "skill"), scoutProvider.skill);
   assert.deepEqual(
@@ -70,13 +80,14 @@ test("disabled targets stay unavailable even when catalogue content is staged", 
   const registry = createCatalogueRegistry([
     scoutProvider,
     coworkProvider,
+    agentSkillProvider,
     stagedCopilotStudioProvider,
   ]);
 
   assert.equal(registry.catalogueFor("copilot-studio", "skill"), null);
   assert.throws(
     () => registry.requireCatalogue("copilot-studio", "skill"),
-    /That target architecture isn't available yet\. Choose Scout or Cowork\./,
+    /That target architecture isn't available yet\. Choose Scout, Cowork, or Agent Skill\./,
   );
 });
 
@@ -166,6 +177,7 @@ test("real providers preserve versions, content, and the support matrix", () => 
   const registry = createCatalogueRegistry([
     scoutCatalogueProvider,
     coworkCatalogueProvider,
+    agentSkillCatalogueProvider,
   ]);
 
   // These hashes prove catalogue moves are byte-for-byte. Intentional catalogue
@@ -188,5 +200,12 @@ test("real providers preserve versions, content, and the support matrix", () => 
   assert.equal(
     sha256(coworkSkill.content),
     "39ffbdf3225ce47eecd735252558cffe860eb6a207782a2f604a8a57fb9a0f68",
+  );
+
+  const agentSkillSkill = registry.requireCatalogue("agent-skill", "skill");
+  assert.equal(agentSkillSkill.version, "2026-08-06");
+  assert.equal(
+    sha256(agentSkillSkill.content),
+    "d5cd96cd8917710aa27b2430358472d947a3cdf3be611cb8f8484d5df2b72789",
   );
 });

--- a/electron/architectures/catalogue-registry.test.ts
+++ b/electron/architectures/catalogue-registry.test.ts
@@ -87,7 +87,7 @@ test("disabled targets stay unavailable even when catalogue content is staged", 
   assert.equal(registry.catalogueFor("copilot-studio", "skill"), null);
   assert.throws(
     () => registry.requireCatalogue("copilot-studio", "skill"),
-    /That target architecture isn't available yet\. Choose Scout, Cowork, or Agent Skill\./,
+    /That target architecture isn't available yet\. Choose Scout, Cowork, or Agent skill\./,
   );
 });
 
@@ -206,6 +206,6 @@ test("real providers preserve versions, content, and the support matrix", () => 
   assert.equal(agentSkillSkill.version, "2026-08-06");
   assert.equal(
     sha256(agentSkillSkill.content),
-    "d5cd96cd8917710aa27b2430358472d947a3cdf3be611cb8f8484d5df2b72789",
+    "27cb863efb3fe973d3b7d4e24359cf5297c1b30fdbc29c073878b57a6d5d8810",
   );
 });

--- a/electron/architectures/catalogues/agent-skill-catalogue.ts
+++ b/electron/architectures/catalogues/agent-skill-catalogue.ts
@@ -1,0 +1,50 @@
+import { defineCatalogueProvider } from "../catalogue-provider";
+
+/**
+ * A **static, versioned** catalogue for a *generic* target: any AI agent that
+ * supports skills. Unlike the Scout and Cowork catalogues, it deliberately lists
+ * NO proprietary built-in tools — a skill built for this target must rely only on
+ * portable capabilities (files, shell/CLIs, documented HTTP APIs) so it can load
+ * into whatever agent the user chooses.
+ */
+export const AGENT_SKILL_CATALOGUE_VERSION = "2026-08-06";
+
+const AGENT_SKILL_CATALOGUE = `
+# Target: Any AI agent with skill support — generic skill catalogue (portable capabilities only)
+
+An **Agent Skill** is a portable \`SKILL.md\` file: optional YAML frontmatter followed by a
+markdown **instructions body** (the standard Copilot skill shape). It targets no specific
+host, so it must NOT assume any proprietary built-in tools.
+
+Frontmatter fields:
+- \`name\` — kebab-case, \`^[a-z0-9-]+$\`.
+- \`description\` — one line of trigger keywords (when the agent should reach for this skill).
+- \`allowed-tools\` (optional) — a YAML list of tool patterns the skill may use, e.g.
+  \`Bash(gh *)\`, \`Read\`, \`Write\`, \`Grep\`, \`Glob\`. Omit it to allow the default set.
+
+The body is plain instructions written TO the agent (imperative voice): when to use the
+skill, the procedure to follow, and how to handle inputs and edge cases.
+
+## Assume only portable capabilities
+
+- Do NOT assume host-specific integrations — no Teams / Outlook / Calendar / WorkIQ, and no
+  browser automation. Rely only on capabilities every agent can reasonably provide: reading
+  and writing files, running shell commands and standard CLIs, and calling documented HTTP APIs.
+- Map each recorded UI action to a portable tool, an API call, or a CLI — never write
+  "click" / "type" UI steps.
+
+## Writing the SKILL.md body
+
+- Write a GENERALIZED procedure: if the recording acted on N specific items, the body loops
+  over ALL items of that kind, not the specific examples that were recorded.
+- Resolve each input via the plan (a fixed value / the user provides it / the agent locates it).
+- Keep it concise and imperative. Include a short "When to use" and the ordered steps.
+`.trim();
+
+export default defineCatalogueProvider({
+  architecture: "agent-skill",
+  skill: {
+    version: AGENT_SKILL_CATALOGUE_VERSION,
+    content: AGENT_SKILL_CATALOGUE,
+  },
+});

--- a/electron/architectures/catalogues/agent-skill-catalogue.ts
+++ b/electron/architectures/catalogues/agent-skill-catalogue.ts
@@ -12,7 +12,7 @@ export const AGENT_SKILL_CATALOGUE_VERSION = "2026-08-06";
 const AGENT_SKILL_CATALOGUE = `
 # Target: Any AI agent with skill support — generic skill catalogue (portable capabilities only)
 
-An **Agent Skill** is a portable \`SKILL.md\` file: optional YAML frontmatter followed by a
+An **Agent skill** is a portable \`SKILL.md\` file: optional YAML frontmatter followed by a
 markdown **instructions body** (the standard Copilot skill shape). It targets no specific
 host, so it must NOT assume any proprietary built-in tools.
 


### PR DESCRIPTION
## Summary

Adds a new **"Agent skill"** build target to skill-recorder: a generic, **export-only** architecture with **no host-specific tools**, for any AI agent that supports skills.

This is a purely **data-driven** addition enabled by the placement refactor in #44 (now on `release/0.4.0`). No new branching logic is needed — the target is expressed entirely through the architecture manifest plus a static catalogue, and the enabled-target → catalogue coverage invariant, `placements`, `installTargetLabel`, and `requireTargetPlacement` APIs from #44 do the rest.

> Base branch is `release/0.4.0` per repo policy (ongoing work lands on the current release branch, not `main`).

## Changes

- **`common/architecture-registry.ts`** — register the `agent-skill` architecture in `ARCHITECTURE_MANIFEST`, placed **before** `copilot-studio` so enabled targets group together. Single `skill` target, `enabled: true`, `placements: ["export"]`. Label is sentence-case **"Agent skill"**; the target `note` (rendered in the build-picker tile) is responsibility-aware: _"Any skill-capable agent. Not tuned to specific tools — you verify it can perform the tasks."_ (mirrored on the architecture `note`). `installTargetLabel` is `"your agent"` — never surfaced (export-only) but kept non-blank to satisfy the manifest invariant.
- **`electron/architectures/catalogues/agent-skill-catalogue.ts`** *(new)* — a static, versioned catalogue (`2026-08-06`) modelled on `cowork-catalogue.ts`. It starts with the required `# Target:` heading and deliberately lists **only portable capabilities** (files, shell/CLIs, documented HTTP APIs) — **no proprietary/native tools**. Auto-registered via `import.meta.glob` (no wiring edits).
- **`common/architecture-registry.test.ts`** — extend the manifest enumeration assertions (`SkillArchitecture.options`, `ARCHITECTURES`, `TARGETS`, `enabledArchitectureLabels("skill")`) to include the new target.
- **`electron/architectures/catalogue-registry.test.ts`** — add the real + mock providers, ensure the default manifest's now-enabled `agent-skill` target has a payload in the relevant tests, update the copilot-studio unavailable-error copy to `Choose Scout, Cowork, or Agent skill`, and add a version + SHA-256 lock (`27cb863e…8810`) mirroring the cowork assertion.

## Validation (all green)

- `npm run typecheck` — passes (exit 0)
- `npm test` — **76 passed, 0 failed**
- `npm run build` — succeeds and prints `Catalogue bundle boundary verified.` (catalogue content is confirmed to stay out of the renderer bundle and present in the Electron bundle)

The catalogue SHA-256 was computed from the actual file (not a pasted value) and matches the locked hash: `27cb863efb3fe973d3b7d4e24359cf5297c1b30fdbc29c073878b57a6d5d8810` (version `2026-08-06`).