### PR TITLE
chore(release): prepare 0.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skill-recorder",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skill-recorder",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-recorder",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Records a user's on-screen work session and derives a structured description for building AI-agent skills.",
   "author": "Skill Recorder contributors",
   "repository": "github:microsoft/skill-recorder",


### PR DESCRIPTION
## Summary

- set the application and lockfile version to `0.4.1`
- preserve the reviewed dependency graph and compliance policy

## Release validation

- `npm run check:lockfile`
- `npm test` (148 passed)
- `npm run build`
- `npm run typecheck:evals`
- `npm run compliance:licenses` (295 package licenses)

This follow-up completes the release metadata required by `RELEASING.md`; the earlier merge contained the two UI fixes but still identified the package as `0.4.0`.