### PR TITLE
Add an agent-skill eval scenario for the skill builder

### DIFF
--- a/evals/skillbuilder/scenarios.ts
+++ b/evals/skillbuilder/scenarios.ts
@@ -177,6 +177,32 @@ const githubIssueTriage: SkillBuilderScenario = {
   },
 };
 
+/** Same recording as githubIssueTriage, targeting the agent-skill (generic) catalogue: must
+ *  still reach for the gh CLI (a universal primitive — the shell), but the plan must name NO
+ *  product-specific tool ID (no workiq_*, no m365_*, no named browser-tool suite) since the
+ *  destination agent is unknown. */
+const githubIssueTriageAgentSkill: SkillBuilderScenario = {
+  ...githubIssueTriage,
+  id: "github-issue-triage-agent-skill",
+  title: "Triage new bug issues on GitHub (agent skill)",
+  architecture: "agent-skill",
+  rubric: {
+    mustUseAny: [["gh "], ["gh issue", "gh api"]],
+    forbidden: [
+      "playwright",
+      "browser_",
+      "workiq",
+      "m365_",
+      "click",
+      "navigate to github",
+      "github.com/acme",
+    ],
+    minValues: 1,
+    minCalculations: 1,
+    minActions: 1,
+  },
+};
+
 /* --- Cowork (Microsoft 365 Copilot) scenarios ----------------------------- */
 
 /** Read a Teams channel in the web app, summarize, post a digest — must use the m365_teams tool, never the browser. */
@@ -249,6 +275,23 @@ const coworkTeamsDigest: SkillBuilderScenario = {
   rubric: {
     mustUseAny: [["m365_teams"], ["postchannelmessage", "postmessage", "replytochannelmessage"]],
     forbidden: ["playwright", "browser_", "click", "teams.microsoft.com"],
+    minCalculations: 1,
+    minActions: 1,
+  },
+};
+
+/** Same Teams recording as coworkTeamsDigest, retargeted to agent-skill — a harder case than
+ *  the gh-CLI scenario since there's no CLI at all for Teams. No proprietary tool exists in the
+ *  agent-skill catalogue for this, so the right generalization is a documented HTTP API call
+ *  (Microsoft Graph) rather than inventing a plausible-sounding native tool name. */
+const teamsDigestAgentSkill: SkillBuilderScenario = {
+  ...coworkTeamsDigest,
+  id: "teams-digest-agent-skill",
+  title: "Post a morning digest to the leads Teams channel (agent skill)",
+  architecture: "agent-skill",
+  rubric: {
+    mustUseAny: [["curl", "web_fetch", "fetch"]],
+    forbidden: ["m365_teams", "workiq", "postchannelmessage", "listchannelmessages", "playwright", "browser_"],
     minCalculations: 1,
     minActions: 1,
   },
@@ -399,6 +442,8 @@ const coworkCalendarSchedule: SkillBuilderScenario = {
 export const skillScenarios: SkillBuilderScenario[] = [
   priceTracker,
   githubIssueTriage,
+  githubIssueTriageAgentSkill,
+  teamsDigestAgentSkill,
   coworkTeamsDigest,
   coworkOutlookReply,
   coworkCalendarSchedule,


### PR DESCRIPTION
## Summary

#47 added the `agent-skill` (generic) architecture but only covered it with structural/manifest tests (`architecture-registry.test.ts`, `catalogue-registry.test.ts`) — nothing exercises the real builder LLM against the new catalogue the way the existing skillbuilder eval suite does for `scout`/`cowork`.

Adds two scenarios to `evals/skillbuilder/scenarios.ts`:

- **`github-issue-triage-agent-skill`** — a clone of the existing `github-issue-triage-skill` scenario, retargeted to `architecture: "agent-skill"`. Requires the `gh` CLI (a universal primitive) while forbidding any vendor-specific tool name (`workiq_*`, `m365_*`, named browser-tool suites).
- **`teams-digest-agent-skill`** — a clone of `cowork-teams-digest`, retargeted to `agent-skill`. A harder case than the `gh`-CLI scenario, since there's no CLI at all for Teams. Confirms the builder doesn't invent a plausible-sounding native tool name when none exists in the catalogue — it correctly falls back to documented Microsoft Graph HTTP calls via `curl` instead.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run eval:skill -- --only=github-issue-triage-agent-skill` — 100% pass against the real Copilot CLI builder; generalizes to `gh` CLI shell steps with zero product-specific tool references
- [x] `npm run eval:skill -- --only=teams-digest-agent-skill` — 100% pass; generalizes to Microsoft Graph HTTP calls (`curl`) rather than inventing a native Teams tool
- [x] Full `npm run eval:skill` suite — no regressions (pre-existing scout/cowork scenarios flaked independent of this change and passed on rerun, consistent with known LLM run-to-run variance)

Related: #19, #47