### PR TITLE
Release 0.4.2

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -258,10 +258,10 @@ Configure a mirror once with:
 npm config set registry <url> --location=global
 ```
 
-To point a single installation at a specific registry without changing any npm
-configuration, set `SKILL_RECORDER_NPM_REGISTRY` to an HTTPS registry URL before
-running the installer. The lockfile's integrity hashes are verified whichever
-registry serves the packages, so a mirror cannot substitute different content.
+The installers never pin or override the registry themselves; they only make the
+machine's existing npm configuration visible to the portable runtime. The
+lockfile's integrity hashes are verified whichever registry serves the packages,
+so a mirror cannot substitute different content.
 
 ## Licensing boundary
 

--- a/install.ps1
+++ b/install.ps1
@@ -676,33 +676,15 @@ if (Test-Path -LiteralPath $sourceDirectory -PathType Container) {
       "scripts\run-reviewed-electron.mjs"
     )
 
-    $registryOverride = $env:SKILL_RECORDER_NPM_REGISTRY
-    if (-not [string]::IsNullOrWhiteSpace($registryOverride)) {
-      $registryOverride = $registryOverride.Trim()
-      $parsedRegistry = $null
-      if (
-        -not [Uri]::TryCreate($registryOverride, [UriKind]::Absolute, [ref]$parsedRegistry) -or
-        $parsedRegistry.Scheme -ne "https"
-      ) {
-        throw "SKILL_RECORDER_NPM_REGISTRY must be an absolute HTTPS URL: $registryOverride"
-      }
-    } else {
-      $registryOverride = $null
-    }
+    $machineNpmConfig = Get-MachineNpmConfigPath
 
     $environmentOverrides = [ordered]@{
       PATH = "$($runtime.Root);$env:PATH"
       NPM_CONFIG_ALLOW_SCRIPTS = $null
     }
-    if ($registryOverride) {
-      Write-Step "Using the npm registry requested by SKILL_RECORDER_NPM_REGISTRY."
-      $environmentOverrides["NPM_CONFIG_REGISTRY"] = $registryOverride
-    } else {
-      $machineNpmConfig = Get-MachineNpmConfigPath
-      if ($machineNpmConfig) {
-        Write-Step "Applying this machine's npm configuration from $machineNpmConfig."
-        $environmentOverrides["NPM_CONFIG_GLOBALCONFIG"] = $machineNpmConfig
-      }
+    if ($machineNpmConfig) {
+      Write-Step "Applying this machine's npm configuration from $machineNpmConfig."
+      $environmentOverrides["NPM_CONFIG_GLOBALCONFIG"] = $machineNpmConfig
     }
 
     $originalEnvironment = @{}
@@ -760,10 +742,10 @@ if (Test-Path -LiteralPath $sourceDirectory -PathType Container) {
       } catch {
         throw (
           "$($_.Exception.Message) Dependencies were requested from $effectiveRegistry. " +
-          "If your network blocks that registry, configure a compatible mirror with " +
-          "'npm config set registry <url> --location=global', or set " +
-          "SKILL_RECORDER_NPM_REGISTRY=<url> before running the installer again. " +
-          "The lockfile's integrity hashes are verified whichever registry serves the packages."
+          "If your network blocks that registry, configure a compatible mirror for this " +
+          "machine with 'npm config set registry <url> --location=global' and run the " +
+          "installer again. The lockfile's integrity hashes are verified whichever " +
+          "registry serves the packages."
         )
       }
 

--- a/install.sh
+++ b/install.sh
@@ -282,16 +282,7 @@ build_source_install() {
   export NPM_CONFIG_CACHE="$INSTALL_ROOT/npm-cache"
   unset NPM_CONFIG_ALLOW_SCRIPTS npm_config_allow_scripts
 
-  if [ -n "${SKILL_RECORDER_NPM_REGISTRY:-}" ]; then
-    case "$SKILL_RECORDER_NPM_REGISTRY" in
-      https://*) ;;
-      *)
-        die "SKILL_RECORDER_NPM_REGISTRY must be an absolute HTTPS URL: $SKILL_RECORDER_NPM_REGISTRY."
-        ;;
-    esac
-    info "Using the npm registry requested by SKILL_RECORDER_NPM_REGISTRY."
-    export NPM_CONFIG_REGISTRY="$SKILL_RECORDER_NPM_REGISTRY"
-  elif [ -n "${MACHINE_NPM_CONFIG:-}" ]; then
+  if [ -n "${MACHINE_NPM_CONFIG:-}" ]; then
     info "Applying this machine's npm configuration from $MACHINE_NPM_CONFIG."
     export NPM_CONFIG_GLOBALCONFIG="$MACHINE_NPM_CONFIG"
   fi
@@ -317,10 +308,10 @@ build_source_install() {
     die "$(
       printf '%s' \
         "npm ci failed. Dependencies were requested from $effective_registry. " \
-        "If your network blocks that registry, configure a compatible mirror with " \
-        "'npm config set registry <url> --location=global', or set " \
-        "SKILL_RECORDER_NPM_REGISTRY=<url> before running the installer again. " \
-        "The lockfile's integrity hashes are verified whichever registry serves the packages."
+        "If your network blocks that registry, configure a compatible mirror for this " \
+        "machine with 'npm config set registry <url> --location=global' and run the " \
+        "installer again. The lockfile's integrity hashes are verified whichever " \
+        "registry serves the packages."
     )"
 
   local policy_key="$PLATFORM-$ARCHITECTURE"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skill-recorder",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skill-recorder",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-recorder",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Records a user's on-screen work session and derives a structured description for building AI-agent skills.",
   "author": "Skill Recorder contributors",
   "repository": "github:microsoft/skill-recorder",


### PR DESCRIPTION
## Summary

Cuts **v0.4.2**, a patch release that makes the source installers work on machines
whose npm registry is configured globally (corporate proxies, including
Microsoft-managed devices), and repairs `main`, which is currently red.

This PR contains two commits:

### 1. `fix(install): drop the registry escape hatch from the installers`

`main@1a1f5e9` is failing both the **Windows** and **Non-Windows** workflows.
PR #57 introduced a `SKILL_RECORDER_NPM_REGISTRY` escape hatch, which made both
installers reference the npm registry environment variable by name. That trips the
deliberate compliance guard in `scripts/compliance.test.mjs` (`source and release
instructions remain compliance-preserving`), which asserts the installers never pin
an npm registry — the exact regression that broke installs in the first place.

The escape hatch was redundant: npm already honours a caller-set registry
environment variable, so users keep the same capability without the installer
sources dictating a registry.

**The actual fix from #57 is untouched.** The installers still point the portable
Node runtime at the machine's existing npm configuration via
`NPM_CONFIG_GLOBALCONFIG`, which *discovers* the configured registry rather than
overriding it. Users with no npm configuration are unaffected — the variable is
only set when a config file actually exists on disk.

`INSTALL.md` now documents `npm config set registry <url> --location=global` as the
supported way to point at a mirror.

### 2. `chore(release): prepare 0.4.2`

Version bump only, in `package.json` and `package-lock.json`.

## User-visible changes since v0.4.1

- Source installs now succeed on networks that block `registry.npmjs.org` but
  provide a mirror through the machine's global npm configuration. Previously the
  portable runtime never read that configuration and fell back to the public
  registry, failing with `ERR_SSL_SSL/TLS_ALERT_HANDSHAKE_FAILURE`.
- `npm ci` failures now report which registry was actually used and how to
  configure a mirror.
- `INSTALL.md` gains a "Networks that block registry.npmjs.org" section.

## Validation

Run with the portable runtime's npm 11.17.0 (`package.json` requires `>=11.17.0`):

- [x] `npm run fix:lockfile-registry` — normalized 0 URLs, no internal feed URLs leaked
- [x] `npm run check:lockfile`
- [x] `npm ci --no-audit --no-fund --ignore-scripts=false --dangerously-allow-all-scripts=false --strict-allow-scripts` — 459 packages
- [x] `npm run compliance:licenses` — 227 package licenses, 0 source materials
- [x] `npm run build`
- [x] `npm run typecheck:evals`
- [x] `npm test` — 147/148 pass; the compliance guard passes again. The one failure
      is environmental only: `electron/debug-bundle.test.ts` shells out to `unzip`,
      which is not present on this Windows machine.
- [x] `bash -n install.sh`
- [x] `scripts/install-windows.test.ps1`
- [x] `install.ps1` parses under both PowerShell 5.1 and 7

End-to-end proof of the underlying fix is in #57: with the fix applied, npm fetched
`zod-4.4.3.tgz` from the corporate proxy instead of the blocked public registry.

## Release model

Source-only, per `RELEASING.md`. No binaries, `dist/`, `dist-electron/`, or
`node_modules/` will be attached to the GitHub Release — this is what keeps us
compliant with third-party licensing.

## Follow-up (not in this PR)

623 of 625 lockfile entries carry SHA-1 integrity (`sha1-…`) rather than
`sha512-…`, because the feed that generated the lockfile only returns the legacy
`dist.shasum`. Worth regenerating from a registry that serves SHA-512.
