### PR TITLE
fix(ui): pin outer width to prevent recorder window growth under fractional scaling

### DIFF
--- a/electron/recorder-window-sizing.test.ts
+++ b/electron/recorder-window-sizing.test.ts
@@ -70,3 +70,38 @@ test("recorder fitting clamps content height and ignores invalid requests", () =
   fitRecorderHeight(win, 500);
   assert.deepEqual(win.size, size);
 });
+
+class FractionalScalingWindow implements RecorderWindowSizingTarget {
+  destroyed = false;
+  size: [number, number] = [401, 500];
+
+  isDestroyed(): boolean {
+    return this.destroyed;
+  }
+
+  getContentSize(): [number, number] {
+    return [this.size[0] - 2, this.size[1] - 31];
+  }
+
+  getSize(): [number, number] {
+    return [...this.size];
+  }
+
+  setSize(width: number, height: number): void {
+    // Simulate a Windows DIP <-> physical pixel round-trip under fractional
+    // display scaling, where the outer size reported back after setSize
+    // doesn't exactly match what was requested.
+    this.size = [width + 2, height];
+  }
+}
+
+test("recorder fitting stays bounded across repeated fractional-scale resizing", () => {
+  const win = new FractionalScalingWindow();
+
+  fitRecorderHeight(win, 600);
+  const widthAfterFirstFit = win.size[0];
+
+  for (let i = 0; i < 10; i++) fitRecorderHeight(win, 600);
+
+  assert.equal(win.size[0], widthAfterFirstFit);
+});


### PR DESCRIPTION
Fixes #56

### Summary
On Windows with fractional display scaling (e.g. 125%), reading outer size on every resize pass and feeding it back into setSize is lossy due to DIP <-> physical pixel conversions. This causes the recorder window width to grow endlessly on every ResizeObserver callback.

### Solution
- Pin the outer window width on the first fit call using a WeakMap.
- Pass the pinned width to win.setSize.
- Add a 2px tolerance threshold (HEIGHT_TOLERANCE) for height settling.
- Add unit test coverage in ecorder-window-sizing.test.ts for fractional display scaling.