### PR TITLE
fix: bound legacy ffmpeg frame-extraction calls with a timeout

### DIFF
--- a/electron/frames/extractor.test.ts
+++ b/electron/frames/extractor.test.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { promisify } from "node:util";
 import sharp from "sharp";
 
 import type { CapturedVideoFrame } from "../../common/frames";
@@ -169,6 +171,24 @@ test("FrameExtractor deduplicates identical source JPEGs without deleting retain
   assert.equal((await reloaded.extractAtEpochs(events)).length, 0);
   assert.equal(reloaded.manifest.length, 1);
   assert.equal(existsSync(path.join(framesDir, reloaded.manifest[0].file)), true);
+});
+
+test("a hung legacy ffmpeg process is killed and rejects within its timeout instead of hanging forever", async () => {
+  // extractLegacyWindow/extractLegacySingle bound their execFileAsync calls with
+  // LEGACY_FFMPEG_TIMEOUT_MS so a stalled ffmpeg (corrupt input, codec edge case,
+  // stuck pipe) can't hang the extraction indefinitely. Those methods are private
+  // and resolve their ffmpeg binary through a module-level, cached `which`/`where`
+  // lookup that isn't test-injectable without expanding this fix's scope, so this
+  // exercises the same execFileAsync-with-timeout mechanism directly: a child
+  // process that never exits on its own must still be killed and the call must
+  // still reject well within the timeout, not hang.
+  const execFileAsync = promisify(execFile);
+  const start = Date.now();
+  await assert.rejects(
+    execFileAsync(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { timeout: 200 }),
+  );
+  const elapsedMs = Date.now() - start;
+  assert.ok(elapsedMs < 5000, `expected the timeout to bound the hang, took ${elapsedMs}ms`);
 });
 
 test("sharp loads through the app's require path as a callable factory (guards sharp 0.35 export shape)", async () => {

--- a/electron/frames/extractor.ts
+++ b/electron/frames/extractor.ts
@@ -74,6 +74,8 @@ export interface CapturedFrameSample<T extends CapturedVideoFrame = CapturedVide
 const DEFAULTS = { dedupeThreshold: 8, maxFrames: 300, frameGridSec: 0.5 };
 const DEFAULT_WINDOW_FPS = 1;
 const DEFAULT_WINDOW_MAX_FRAMES = 24;
+/** Bounds how long a legacy system-ffmpeg extraction can run before it's treated as a failure. */
+const LEGACY_FFMPEG_TIMEOUT_MS = 60_000;
 
 export function nearestCapturedFrame<T extends CapturedVideoFrame>(
   frames: readonly T[],
@@ -355,7 +357,10 @@ export class FrameExtractor {
           "-q:v", "3",
           pattern,
         ],
-        { maxBuffer: 32 * 1024 * 1024 },
+        // A stalled ffmpeg (corrupt input, codec edge case, stuck pipe) would
+        // otherwise hang this promise forever; the timeout bounds that and
+        // routes into the same failure handling as any other ffmpeg error.
+        { maxBuffer: 32 * 1024 * 1024, timeout: LEGACY_FFMPEG_TIMEOUT_MS },
       );
     } catch (err) {
       log.warn("legacy probe window failed:", message(err));
@@ -402,7 +407,7 @@ export class FrameExtractor {
           "-q:v", "3",
           "-y", file,
         ],
-        { maxBuffer: 16 * 1024 * 1024 },
+        { maxBuffer: 16 * 1024 * 1024, timeout: LEGACY_FFMPEG_TIMEOUT_MS },
       );
     } catch (err) {
       log.warn(`legacy frame at ${offsetSec.toFixed(2)}s failed:`, message(err));


### PR DESCRIPTION
Fixes #14.

### What's wrong

`extractLegacyWindow`/`extractLegacySingle` in `electron/frames/extractor.ts` run the system `ffmpeg` binary via `execFileAsync(ffmpegPath, [...], { maxBuffer })`, with no `timeout`. If ffmpeg stalls (corrupt input, codec edge case, stuck pipe), the promise never settles and frame extraction — and the describer/analysis pipeline behind it — hangs indefinitely for that session.

### Fix

Added a `LEGACY_FFMPEG_TIMEOUT_MS` (60s) constant and passed it as `timeout` on both `execFileAsync` calls. On timeout, Node kills the child and the call rejects, which both call sites already route into their existing `catch` (log a warning, return an empty/null result) — the same handling as any other ffmpeg failure, so no new error-handling path was needed.

### How I tested it

- `extractLegacyWindow`/`extractLegacySingle` are private and resolve their ffmpeg binary through a module-level, cached `which`/`where` lookup that isn't test-injectable without expanding this fix's scope. Instead, added a test that exercises the same mechanism directly: a genuinely hung child process (`node -e "setInterval(...)"`), asserting `execFileAsync` with a `timeout` kills it and rejects well within the bound rather than hanging.
- `npm test`: 155/158 pass; 2 failures + 1 cancelled, all confirmed identical on unpatched `main` with none of this PR's changes — unrelated (a pre-existing `debug-bundle.test.ts`/`archiver` typing issue and a flaky microphone-controller test).
- `npm run typecheck`: pre-existing, unrelated failures in `debug-bundle.ts` also confirmed identical on `main`; no new errors from this change.