### PR TITLE
fix(deps): bump nanoid to patch CVE-2026-67213 (GHSA-2v37-7h3g-55p8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6177,9 +6177,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha1-oE2OxLHxAAnS1TOUeu/kKTc3gWw=",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

`nanoid@3.3.16` (transitive dependency of `postcss`, pulled in via `vite` — devDependency, build-time only) is affected by [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) / CVE-2026-67213: custom generators can loop indefinitely when `size` is zero. Fixed upstream in `nanoid@3.3.18`.

## Fix

Lockfile-only bump of the transitive `nanoid` resolution to `3.3.18`. `postcss@8.5.25` (the direct consumer) already declares `"nanoid": "^3.3.16"`, so `3.3.18` resolves cleanly within its existing declared range — no `package.json` changes needed.

```diff
     "node_modules/nanoid": {
-      "version": "3.3.16",
+      "version": "3.3.18",
```

## Verification
- Reproduced locally: n/a (dependency-scan finding, not a code-level repro)
- Method: `osv-scanner --recursive .` before/after
- Before: `nanoid@3.3.16` flagged for GHSA-2v37-7h3g-55p8
- After: `osv-scanner` reports zero nanoid findings
- Impact scope: devDependency only (`vite` build tooling), not present in shipped app bundles

## Detected by

osv-scanner (dependency vulnerability scan).